### PR TITLE
Re-factors SQL join statements, so that an

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -30,8 +30,6 @@ module Admin
     end
 
     def update
-      # This lookup is due to the original find coming back read only
-      @organization = Organization.find(@organization.id)
       if @organization.update_attributes(organization_params)
         redirect_to [:admin, @organization], notice:"Saved #{@organization.name}"
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,9 +23,10 @@ class User < ActiveRecord::Base
       Organization.all
     elsif market_manager?
       Organization.
+        select("DISTINCT organizations.*").
         joins("LEFT JOIN user_organizations ON user_organizations.organization_id = organizations.id
                LEFT JOIN market_organizations ON market_organizations.organization_id = organizations.id").
-        where(["user_organizations.user_id = ? OR market_organizations.market_id IN (?)", id, managed_markets_join.map(&:market_id)]).uniq
+        where(["user_organizations.user_id = ? OR market_organizations.market_id IN (?)", id, managed_markets_join.map(&:market_id)])
     else
       organizations
     end
@@ -36,12 +37,14 @@ class User < ActiveRecord::Base
       Market.all
     elsif market_manager?
       Market.
+        select("DISTINCT markets.*").
         joins("LEFT JOIN market_organizations ON market_organizations.market_id = markets.id
                LEFT JOIN user_organizations ON user_organizations.organization_id = market_organizations.organization_id
                LEFT JOIN managed_markets ON managed_markets.market_id = markets.id").
-        where(["user_organizations.user_id = ? OR managed_markets.user_id = ?", id, id]).uniq
+        where(["user_organizations.user_id = ? OR managed_markets.user_id = ?", id, id])
     else
       Market.
+        select("DISTINCT markets.*").
         joins("INNER JOIN market_organizations ON market_organizations.market_id = markets.id
                INNER JOIN user_organizations ON user_organizations.organization_id = market_organizations.organization_id").
         where("user_organizations.user_id" => id)


### PR DESCRIPTION
Re-factors SQL join statements, so that an additional find is 
not required to remove the :readonly attribute on ActiveRecord
models.
