### PR TITLE
Re-factored test using selectors into a Domino DSL.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ end
 group :test do
   gem 'codeclimate-test-reporter', require: nil
   gem 'capybara'
+  gem 'domino'
   gem 'factory_girl_rails'
   gem 'email_spec'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       devise (>= 3.1.0)
     diff-lcs (1.2.5)
     docile (1.1.2)
+    domino (0.5.0)
+      capybara (>= 0.4.0)
     email_spec (1.5.0)
       launchy (~> 2.1)
       mail (~> 2.2)
@@ -229,6 +231,7 @@ DEPENDENCIES
   debugger
   devise
   devise_invitable
+  domino
   email_spec
   factory_girl_rails
   figaro!

--- a/spec/features/selling/add_product_spec.rb
+++ b/spec/features/selling/add_product_spec.rb
@@ -17,18 +17,21 @@ describe "Adding a product" do
     context "using the choose category typeahead", js: true do
       it "can quickly drill down to a result" do
         fill_in "Product Name", with: "Red Grapes"
-        page.find("a", text: "Select a Category").click
-        expect(page).to have_content("Macintosh Apples")
-        expect(page).to have_content("Turnips")
 
-        page.find("#product_category_id_chosen .chosen-search").native.send_keys("grapes")
+        category_select = Dom::CategorySelect.first
+        category_select.click
 
-        expect(page).to have_content("Red Grapes")
-        expect(page).to have_content("Green Grapes")
-        expect(page).to_not have_content("Macintosh Apples")
-        expect(page).to_not have_content("Turnips")
+        expect(category_select.visible_options).to have_text("Macintosh Apples")
+        expect(category_select.visible_options).to have_text("Turnips")
 
-        page.find("li", text: "Fruits / Grapes / Red Grapes").click
+        category_select.type_search("grapes")
+
+        expect(category_select.visible_options).to have_text("Red Grapes")
+        expect(category_select.visible_options).to have_text("Green Grapes")
+        expect(category_select.visible_options).to_not have_text("Turnips")
+        expect(category_select.visible_options).to_not have_text("Macintosh Apples")
+
+        category_select.visible_option("Fruits / Grapes / Red Grapes").click
 
         click_button "Add Product"
 

--- a/spec/support/domino.rb
+++ b/spec/support/domino.rb
@@ -1,0 +1,21 @@
+module Dom
+  class CategorySelect < Domino
+    selector "#product_category_id_chosen"
+
+    def click
+      page.find("a", text: "Select a Category").click
+    end
+
+    def visible_options
+      node.all(".active-result").map(&:text)
+    end
+
+    def visible_option(text)
+      node.find("li", text: text)
+    end
+
+    def type_search(term)
+      node.find(".chosen-search input").set(term)
+    end
+  end
+end


### PR DESCRIPTION
I wanted to pull some of the selectors we are using to test Harvest's Chosen into a DSL. My reasoning is that:
1. If we decide to stick w/ Chosen, we will want re-usable steps to test it.
2. If we decide to remove Chosen, the over-arching behavior an alternative would provide will still be the same. So there would only be a single point in code which we'd have change selectors, and interactions.
