### PR TITLE
Remove dashboard link as it's in the global navigation now.

### DIFF
--- a/app/views/admin/markets/index.html.erb
+++ b/app/views/admin/markets/index.html.erb
@@ -1,6 +1,5 @@
 <div>
   <h1>Markets</h1>
-  <%= link_to 'Dashboard', dashboard_path %>
   <%= link_to 'Add Market', new_admin_market_url if current_user.admin? %>
 </div>
 

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -1,6 +1,5 @@
 <div>
   <h1>Organizations</h1>
-  <%= link_to 'Dashboard', dashboard_path %>
   <%= link_to 'Add Organization', new_admin_organization_path if current_user.admin? || current_user.market_manager? %>
 </div>
 


### PR DESCRIPTION
The dashboard link is in the global header now.

This change removes additional "Dashboard" links that are no longer needed.
