### PR TITLE
Ensure location errors show even when a market has not been chosen.

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -15,6 +15,7 @@ module Admin
     def create
       if params[:initial_market_id].blank?
         @organization = Organization.new(organization_params)
+        @organization.valid?
         @organization.errors.add(:markets, :blank)
       else
         @market = current_user.markets.find(params[:initial_market_id])

--- a/spec/features/market_manager/managing_organizations_spec.rb
+++ b/spec/features/market_manager/managing_organizations_spec.rb
@@ -82,9 +82,15 @@ describe "A Market Manager" do
           click_button 'Add Organization'
 
           expect(page).to have_content("Markets can't be blank")
+          expect(page).to have_content("Location name can't be blank")
+          expect(page).to have_content("Address can't be blank")
+          expect(page).to have_content("City can't be blank")
+          expect(page).to have_content("State can't be blank")
+          expect(page).to have_content("Postal code can't be blank")
         end
       end
     end
+
 
     context "with a blank name" do
       it "doesn't add the new organization" do


### PR DESCRIPTION
Due to validations in the Admin::OrganizationsController, the full set of error messages were not showing when adding  a new organization.
