### PR TITLE
Fix error in rake deploy commands 

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -9,7 +9,7 @@ namespace :deploy do
       system "heroku run --app #{app} rake db:migrate"
       system "heroku restart --app #{app}"
 
-      version = `heroku releases --app #{app} -n 1 | grep -o 'v[0-9]*'`
+      version = `heroku releases --app #{app} -n 1 | grep -o '^v[0-9]*'`
       system "git tag #{version}"
       system "git push --tags"
     end
@@ -25,7 +25,7 @@ namespace :deploy do
       system "heroku run --app #{app} rake db:migrate"
       system "heroku restart --app #{app}"
 
-      version = `heroku releases --app #{app} -n 1 | grep -o 'v[0-9]*'`
+      version = `heroku releases --app #{app} -n 1 | grep -o '^v[0-9]*'`
       system "git tag #{version}"
       system "git push --tags"
     end


### PR DESCRIPTION
when there was another letter "v" in the output (such as in collectVeidea.com) it was throwing an useless error. 
