### PR TITLE
Use a canonical hostname

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'interactor-rails'
 gem 'newrelic_rpm'
 gem 'jquery-ui-rails'
 gem 'periscope-activerecord'
+gem 'rack-canonical-host'
 
 group :doc do
   gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,9 @@ GEM
     pry-rails (0.3.2)
       pry (>= 0.9.10)
     rack (1.5.2)
+    rack-canonical-host (0.0.8)
+      addressable
+      rack (~> 1.0)
     rack-test (0.6.2)
       rack (>= 1.0)
     rails (4.1.0.rc1)
@@ -287,6 +290,7 @@ DEPENDENCIES
   pg
   poltergeist
   pry-rails
+  rack-canonical-host
   rails (= 4.1.0.rc1)
   rails_12factor
   rspec-rails (~> 3.0.0.beta2)

--- a/config.ru
+++ b/config.ru
@@ -2,4 +2,11 @@
 
 require ::File.expand_path('../config/environment',  __FILE__)
 use Rack::Deflater
+
+if ENV["DOMAIN"]
+  # Dont' take my word for it: http://rubular.com/r/YtzRyVnuDB
+  regexp = /^(?!.*#{Regexp.escape(ENV["DOMAIN"])}$).*$/
+  use Rack::CanonicalHost, ENV["DOMAIN"], if: regexp
+end
+
 run Rails.application


### PR DESCRIPTION
- [ ] Write Tests

Redirects hosts like localorbit-staging.herokuapp.com

We had issues where now that we're setting cookies [See #79] for the subdomains, but it breaks localorbit-staging.herokuapp.com. This ensures you're on the correct base hostname or a subdomain and redirects you if not.

The regular expression we're using is shown here: http://rubular.com/r/YtzRyVnuDB
