### PR TITLE
Hide the "Market will pickup..." checkbox

### DIFF
--- a/app/assets/javascripts/delivery_schedule.js.coffee
+++ b/app/assets/javascripts/delivery_schedule.js.coffee
@@ -2,7 +2,9 @@ $ ->
   $("#delivery_schedule_seller_fulfillment_location_id").change ->
     if $(this).val() == "0"
       $("#buyer_order_receipt").addClass('is-hidden')
+      $("#market_pickup_option").addClass('is-hidden')
       $("#buyer_order_receipt select").attr("readonly", true).attr("disabled", true)
     else
       $("#buyer_order_receipt").removeClass('is-hidden')
+      $("#market_pickup_option").removeClass('is-hidden')
       $("#buyer_order_receipt select").attr("readonly", false).attr("disabled", false)

--- a/app/views/admin/delivery_schedules/_form.html.erb
+++ b/app/views/admin/delivery_schedules/_form.html.erb
@@ -35,7 +35,7 @@
   <%= f.select :seller_fulfillment_location_id, @market.fulfillment_locations('Direct to customer') %>
 </div>
 
-<div class="field">
+<div class="field<%= ' is-hidden' unless f.object.buyer_pickup? %>" id="market_pickup_option">
   <%= f.check_box :market_pickup %>
   <%= f.label :market_pickup, 'Market will pickup from seller location.' %>
 </div>

--- a/spec/features/market_manager/managing_delivery_schedules_spec.rb
+++ b/spec/features/market_manager/managing_delivery_schedules_spec.rb
@@ -32,6 +32,7 @@ describe 'Market Manager managing delivery schedules' do
     click_link 'Add Delivery'
 
     expect(page).to_not have_content("Buyer pickup start")
+    expect(page).to_not have_content("Market will pickup from seller location")
 
     select 'Tuesday', from: 'Day'
     fill_in 'Order cutoff', with: '6'
@@ -40,12 +41,14 @@ describe 'Market Manager managing delivery schedules' do
     select '11:30 AM', from: 'Seller delivery end'
 
     expect(page).to have_content("Buyer pickup start")
+    expect(page).to have_content("Market will pickup from seller location")
 
     select '12:00 PM', from: 'Buyer pickup start'
     select '11:00 AM', from: 'Buyer pickup end'
 
     click_button 'Save Delivery'
 
+    expect(page).to have_content("Market will pickup from seller location")
     expect(page).to have_content('Buyer pickup end must be after buyer pickup start')
     expect(page).to have_content('Buyer pickup start')
   end


### PR DESCRIPTION
If the seller fulfillment is "Direct to customer", hide the "Market will pickup from seller location" checkbox.
