### PR TITLE
Allow overriding the s3 hostname

### DIFF
--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -21,6 +21,7 @@ Dragonfly.app.configure do
     secret_access_key: Figaro.env.uploads_secret_access_key,
     region:            Figaro.env.uploads_region,
     url_scheme:        "https",
+    url_host:          Figaro.env.uploads_host,
     headers:           s3_headers
 
   Fog.mock! if Rails.env.test?


### PR DESCRIPTION
The default hostname is not behaving for US-west. Need this to add the override on heroku
