### PR TITLE
Remove Inventory link until Product is saved with advanced inventory

### DIFF
--- a/app/assets/javascripts/products.js.coffee
+++ b/app/assets/javascripts/products.js.coffee
@@ -180,6 +180,10 @@ $ ->
   ########################################
   # Events
   ########################################
+  if $('#product_use_simple_inventory').is(':checked')
+    inventoryTab = $('#product-inventory-nav a').contents()
+    inventoryTab.unwrap().wrap('<span></span>')
+
   $("#seller_info").change ->
     val = $(this).prop("checked")
     formModel.changeSellerInfo(val)

--- a/spec/features/selling/edit_product_spec.rb
+++ b/spec/features/selling/edit_product_spec.rb
@@ -1,4 +1,3 @@
-
 require "spec_helper"
 
 describe "Editing a product" do
@@ -86,6 +85,8 @@ describe "Editing a product" do
         within(".tabs") do
           expect(page).to have_content("Inventory")
         end
+
+        expect(page).not_to have_selector(:link_or_button, "Inventory")
       end
     end
   end


### PR DESCRIPTION
Addresses this bug:
https://www.pivotaltracker.com/story/show/65809428
