### PR TITLE
Change session key for non-production environments

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store,
-  key: '_local_orbit_session',
+  key: (Rails.env.production? ? "_local_orbit_session" : "_local_orbit_session_#{Rails.env}"),
   domain: (Rails.env.test? || Figaro.env.domain == 'localhost') ? :all : ".#{Figaro.env.domain}"

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 feature "User signing in" do
   let!(:user) { create(:user, :admin) }
+  let(:cookie_name) { "_local_orbit_session_test" }
 
   scenario "A user can sign in" do
     visit "/"
@@ -22,7 +23,7 @@ feature "User signing in" do
 
     # Hack to remove a cookie from the cookie jar
     jar = Capybara.current_session.driver.browser.current_session.instance_variable_get(:@rack_mock_session).cookie_jar
-    jar.delete('_local_orbit_session')
+    jar.delete(cookie_name)
 
     visit new_user_session_path
     expect(page).to have_text("Dashboard")
@@ -38,7 +39,7 @@ feature "User signing in" do
 
     # Hack to remove a cookie from the cookie jar
     jar = Capybara.current_session.driver.browser.current_session.instance_variable_get(:@rack_mock_session).cookie_jar
-    jar.delete('_local_orbit_session')
+    jar.delete(cookie_name)
 
     visit "/"
     expect(page).to_not have_text("Dashboard")


### PR DESCRIPTION
Otherwise they clobber each other on *.localorbit.com and *.next.localorbit.com
