### PR TITLE
Support unicode subdomains

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'jquery-ui-rails'
 gem 'periscope-activerecord'
 gem 'rack-canonical-host'
 gem 'kaminari'
+gem 'simpleidn'
 
 group :doc do
   gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
+    simpleidn (0.0.5)
     slop (3.5.0)
     spring (1.1.2)
     spring-commands-rspec (1.0.1)
@@ -363,6 +364,7 @@ DEPENDENCIES
   sass-rails (~> 4.0.0)
   sdoc
   simplecov (~> 0.7.1)
+  simpleidn
   spring
   spring-commands-rspec
   timecop

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,8 +58,8 @@ class ApplicationController < ActionController::Base
   end
 
   def market_for_current_subdomain(scope = Market)
-    subdomain = request.subdomains(Figaro.env.domain.count('.'))
-    scope.find_by(subdomain: subdomain)
+    subdomain = request.subdomains(Figaro.env.domain.count('.')).first
+    scope.find_by(subdomain: SimpleIDN.to_unicode(subdomain))
   end
 
   def on_main_domain?

--- a/lib/constraints/non_market_domain.rb
+++ b/lib/constraints/non_market_domain.rb
@@ -1,10 +1,10 @@
 class NonMarketDomain
   def matches?(request)
-    subdomain = request.subdomains(Figaro.env.domain.count('.'))
+    subdomain = request.subdomains(Figaro.env.domain.count('.')).try(:first)
     request.host != Figaro.env.domain && !market_exists?(subdomain)
   end
 
   def market_exists?(subdomain)
-    Market.where(subdomain: subdomain).exists?
+    Market.where(subdomain: SimpleIDN.to_unicode(subdomain)).exists?
   end
 end

--- a/spec/features/navigating_markets_spec.rb
+++ b/spec/features/navigating_markets_spec.rb
@@ -54,6 +54,21 @@ feature "A user navagating markets" do
     end
   end
 
+  context "a user with one market on a unicode domain" do
+    let!(:market) { create(:market, subdomain: "👍", organizations: [seller_org, buyer_org]) }
+
+    scenario "a user navigating to their market" do
+      switch_to_subdomain SimpleIDN.to_ascii(market.subdomain)
+      visit '/'
+      # expect(page).to have_content(market.name)
+
+      sign_in_as(user)
+      expect(page).to have_content(market.name)
+      expect(page).to have_content(market.tagline)
+      expect(page).to have_content("Welcome")
+    end
+  end
+
   context "signing in" do
     let!(:market) { create(:market, organizations: [seller_org, buyer_org]) }
     let!(:delivery_schedule) { create(:delivery_schedule, market: market) }


### PR DESCRIPTION
@albus522 we had a hidden error. `request.subdomains(Figaro.env.domain.count('.'))` was returning an array of the subdomain `["foo"]` so it properly worked for DB lookups, but the punycode conversion didn't take effect because it wasn't a string. 
