### PR TITLE
nullify blank params in bank account creation

### DIFF
--- a/app/interactors/underwrite_entity.rb
+++ b/app/interactors/underwrite_entity.rb
@@ -3,6 +3,7 @@ class UnderwriteEntity
 
   def setup
     context[:balanced_customer] ||= Balanced::Customer.find(entity.balanced_customer_uri)
+    representative_params.delete_if {|k,v| v.blank?}
   end
 
   def perform

--- a/spec/interactors/underwrite_entity_spec.rb
+++ b/spec/interactors/underwrite_entity_spec.rb
@@ -5,9 +5,23 @@ describe UnderwriteEntity do
   subject(:interactor) { UnderwriteEntity.new(balanced_customer: balanced_customer, representative_params: representative_params, entity: org) }
 
   let(:org) { create(:organization, name: "Our Org") }
+  let(:balanced_customer) { OpenStruct.new }
+
+  describe "#setup" do
+    let(:representative_params) do
+      {
+        name: "",
+        ssn_last4: "",
+      }
+    end
+
+    it "clears nil values in representative_params" do
+      expect(interactor.representative_params[:name]).to be_nil
+      expect(interactor.representative_params[:ssn_last_4]).to be_nil
+    end
+  end
 
   describe "#perform" do
-    let(:balanced_customer) { OpenStruct.new }
     let(:representative_params) do
       {
         name: "John Doe",


### PR DESCRIPTION
Balanced breaks if we send empty top-level strings like name or ssn_last_4
See: https://docs.balancedpayments.com/1.0/api/customers/#creating-a-customer
