### PR TITLE
Change origin for CORS

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,7 @@ module LocalOrbit
 
     config.middleware.use Rack::Cors do
       allow do
-        origins Figaro.env.domain, "*.#{Figaro.env.domain}"
+        origins "*"
         resource '/assets/*', headers: :any, methods: :get
       end
     end


### PR DESCRIPTION
CloudFront doesn't vary on Origin so we need to always set this.

Cloudfront _should_ always send an Origin header though, so this should work.
