### PR TITLE
Use app.localorbit.com for the base domain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,7 +68,7 @@ class ApplicationController < ActionController::Base
   end
 
   def on_main_domain?
-    request.host == Figaro.env.domain
+    request.host == Figaro.env.domain || request.host == "app.#{Figaro.env.domain}"
   end
 
   def current_delivery

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -1,5 +1,6 @@
 class Market < ActiveRecord::Base
   validates :name, :subdomain, uniqueness: true, length: {maximum: 255, allow_blank: true}
+  validates :subdomain, exclusion: { in: %w(app www mail ftp smtp imap docs calendar community service support)}
   validates :tagline, length: {maximum: 255, allow_blank: true}
   validates :local_orbit_seller_fee, :local_orbit_market_fee, :market_seller_fee, :credit_card_seller_fee, :credit_card_market_fee, :ach_seller_fee, :ach_market_fee, presence: true, numericality: { greater_than_or_equal_to: 0, less_than: 100, allow_blank: true }
   validates :ach_fee_cap, presence: true, numericality: { greater_than_or_equal_to: 0, less_than: 10_000, allow_blank: true }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   get '*path', constraints: NonMarketDomain.new, format: false,
     to: redirect {|params, request|
-      "#{request.protocol}#{Figaro.env.domain}/#{params[:path]}"
+      "#{request.protocol}app.#{Figaro.env.domain}/#{params[:path]}"
     }
 
   devise_for :users, skip: [:registrations]

--- a/lib/constraints/non_market_domain.rb
+++ b/lib/constraints/non_market_domain.rb
@@ -1,7 +1,7 @@
 class NonMarketDomain
   def matches?(request)
     subdomain = request.subdomains(Figaro.env.domain.count('.')).try(:first)
-    request.host != Figaro.env.domain && !market_exists?(subdomain)
+    request.host != Figaro.env.domain && subdomain != "app" && !market_exists?(subdomain)
   end
 
   def market_exists?(subdomain)

--- a/spec/features/navigating_markets_spec.rb
+++ b/spec/features/navigating_markets_spec.rb
@@ -11,15 +11,22 @@ feature "A user navagating markets" do
       expect(page).to have_content("Please Sign In")
       expect(page).to have_css("img[src='/assets/logo.png']")
     end
+    
+    scenario "a visitor sees the 'app' domain" do
+      switch_to_subdomain "app"
+      visit '/'
+      expect(page).to have_content("Please Sign In")
+      expect(page).to have_css("img[src='/assets/logo.png']")
+    end
 
-    scenario "a visitor to a non-existant subdomain is redirected to the base domain" do
+    scenario "a visitor to a non-existant subdomain is redirected to the 'app' domain" do
       switch_to_subdomain "not-real-ever"
       visit '/'
       host = URI.parse(page.current_host).host
-      expect(host).to eq(Figaro.env.domain)
+      expect(host).to eq("app.#{Figaro.env.domain}")
     end
 
-    scenario "a visitor to a subdomain sees the sign in page" do
+    scenario "a visitor to a market subdomain sees the sign in page" do
       market = create(:market, :with_logo)
       switch_to_subdomain market.subdomain
       visit '/'

--- a/spec/lib/constraints/non_market_domain_spec.rb
+++ b/spec/lib/constraints/non_market_domain_spec.rb
@@ -13,18 +13,25 @@ describe NonMarketDomain do
       expect(constraint.matches?(request)).to be(false)
     end
 
+    it "returns false if the subdomain is the 'app' subdomain" do
+      allow(request).to receive(:subdomains).and_return(['app'])
+      allow(request).to receive(:host).and_return("app.#{base_domain}")
+
+      expect(constraint.matches?(request)).to be(false)
+    end
+
     it "returns false if the subdomain is a market subdomain" do
-      allow(request).to receive(:subdomains).and_return('real')
+      allow(request).to receive(:subdomains).and_return(['real'])
       allow(request).to receive(:host).and_return("real.#{base_domain}")
-      allow(constraint).to receive(:market_exists?).and_return(true)
+      allow(constraint).to receive(:market_exists?).with("real").and_return(true)
 
       expect(constraint.matches?(request)).to be(false)
     end
 
     it "returns true if the subdomain is not a market subdomain" do
-      allow(request).to receive(:subdomains).and_return('fake')
+      allow(request).to receive(:subdomains).and_return(['fake'])
       allow(request).to receive(:host).and_return("fake.#{base_domain}")
-      allow(constraint).to receive(:market_exists?).and_return(false)
+      allow(constraint).to receive(:market_exists?).with("fake").and_return(false)
 
       expect(constraint.matches?(request)).to be(true)
     end

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -38,6 +38,14 @@ describe Market do
         expect(market).to_not be_valid
         expect(market).to have(1).error_on(:subdomain)
       end
+      
+      it "cannot be a reserved name" do
+        market = build(:market)
+        market.subdomain = "app"
+
+        expect(market).to_not be_valid
+        expect(market).to have(1).error_on(:subdomain)
+      end
     end
 
     it 'tagline can be at most 255 characters' do


### PR DESCRIPTION
Allows localorbit.com to be the marketing site.

`DOMAIN` will still be set to `localorbit.com` (or `next.localorbit.com` for staging) this just recognizes `app.DOMAIN` as the same as plain `DOMAIN` and uses that for redirection.
