### PR TITLE
Show a helpful message when trying to checkout with an empty cart.

### DIFF
--- a/app/views/carts/_link.html.erb
+++ b/app/views/carts/_link.html.erb
@@ -1,3 +1,21 @@
-<%= link_to [:cart], class: (current_page?([:cart]) ? "current cart" : "cart" ) do %>
-  Cart <span class="counter"><%= current_cart.present? ? current_cart.items.count : 0 %></span>
+<% cart_class_base = (current_page?([:cart]) ? "current cart" : "cart" ) %>
+
+<% if current_cart.present? && (current_cart.items.count > 0) %>
+  <%= link_to [:cart], class: cart_class_base  do %>
+    Cart <span class="counter"><%= current_cart.items.count %></span>
+  <% end %>
+<% else %>
+  <%= link_to "#empty-cart", class: "#{cart_class_base} popup-toggle" do %>
+    Cart <span class="counter">0</span>
+  <% end %>
 <% end %>
+
+<div id="empty-cart" class="popup is-hidden">
+  <div class="popup-header">
+    Your cart is empty.
+  </div>
+
+  <div class="popup-body">
+    <p>Add items to your cart to see them here and make a purchase.</p>
+  </div>
+</div>

--- a/spec/features/buying/checking_out_spec.rb
+++ b/spec/features/buying/checking_out_spec.rb
@@ -79,6 +79,7 @@ describe "Checking Out" do
     fill_in "PO Number", with: "12345"
   end
 
+
   it "displays copy about the order" do
     checkout
     expect(page).to have_content("You will receive a confirmation email with details of your order and a link to track its progress")

--- a/spec/features/buying/viewing_empty_cart_spec.rb
+++ b/spec/features/buying/viewing_empty_cart_spec.rb
@@ -13,9 +13,8 @@ describe "Viewing an empty cart" do
       switch_to_subdomain(market.subdomain)
       expect(Dom::CartLink.first.node).to have_content("0")
       click_link "Cart", match: :first
-      within "h1" do
-        expect(page).to have_content("Cart")
-      end
+      expect(page).to have_content("Your cart is empty.")
+      expect(page).to have_content("Add items to your cart to see them here and make a purchase.")
     end
   end
 
@@ -25,9 +24,8 @@ describe "Viewing an empty cart" do
       switch_to_subdomain(market.subdomain)
       expect(Dom::CartLink.first.node).to have_content("0")
       click_link "Cart"
-      within "h1" do
-        expect(page).to have_content("Cart")
-      end
+      expect(page).to have_content("Your cart is empty.")
+      expect(page).to have_content("Add items to your cart to see them here and make a purchase.")
     end
   end
 


### PR DESCRIPTION
@mercilessrobot @mattslack This PR needs design eyes on it.

[Fixes #69089060]
