### PR TITLE
⚠️ Add a base mailer class to set default From headers

### DIFF
--- a/app/mailers/base_mailer.rb
+++ b/app/mailers/base_mailer.rb
@@ -1,0 +1,25 @@
+class BaseMailer < ActionMailer::Base
+  layout "email"
+  default(
+    from: Proc.new { default_from },
+    reply_to: Proc.new { default_reply_to },
+  )
+
+  private
+
+  def default_from
+    if @market
+      "#{@market.name} <service@localorb.it>"
+    else
+      "Local Orbit <service@localorb.it>"
+    end
+  end
+
+  def default_reply_to
+    if @market
+      "#{@market.contact_name} <#{@market.contact_email}>"
+    else
+      nil
+    end
+  end
+end

--- a/app/mailers/market_mailer.rb
+++ b/app/mailers/market_mailer.rb
@@ -1,6 +1,4 @@
-class MarketMailer < ActionMailer::Base
-  layout "email"
-  default from: "service@localorb.it"
+class MarketMailer < BaseMailer
 
   def fresh_sheet(market, recipients=nil, preview=false)
     @preview = preview

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -1,7 +1,4 @@
-class OrderMailer < ActionMailer::Base
-  layout "email"
-  default from: "service@localorb.it"
-
+class OrderMailer < BaseMailer
   def buyer_confirmation(order)
     @market = order.market
     @order = BuyerOrder.new(order)
@@ -34,6 +31,7 @@ class OrderMailer < ActionMailer::Base
 
   # TODO: Attach invoice PDF
   def invoice(order, addresses)
+    @market = order.market
     @order = order
 
     mail(

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,4 @@
-class UserMailer < ActionMailer::Base
-  layout "email"
-  default from: "service@localorb.it"
-
+class UserMailer < BaseMailer
   def organization_invitation(user, organization, inviter, market)
     @user = user
     @organization = organization

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -4,6 +4,7 @@ class Market < ActiveRecord::Base
   validates :tagline, length: {maximum: 255, allow_blank: true}
   validates :local_orbit_seller_fee, :local_orbit_market_fee, :market_seller_fee, :credit_card_seller_fee, :credit_card_market_fee, :ach_seller_fee, :ach_market_fee, presence: true, numericality: {greater_than_or_equal_to: 0, less_than: 100, allow_blank: true}
   validates :ach_fee_cap, presence: true, numericality: {greater_than_or_equal_to: 0, less_than: 10_000, allow_blank: true}
+  validates :contact_name, :contact_email, presence: true
 
   before_save :clean_twitter_slug
 


### PR DESCRIPTION
Requires validations on market contact info. We'll have to be careful of this on existing markets, but we need to get these defaults in (see BaseMailer default section). 

Any thoughts?
