### PR TITLE
Make dragonfly work with dynamic image creation

### DIFF
--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -7,6 +7,7 @@ Dragonfly.app.configure do
   protect_from_dos_attacks true
   secret "c8583e781acd7fdbb14323520b44d98d1b29c345cfcbcb0003078a6bc4da670b"
 
+  url_host   Figaro.env.asset_host
   url_format "/media/:job/:name"
 
   s3_headers = {
@@ -35,6 +36,9 @@ end
 
 # Logger
 Dragonfly.logger = Rails.logger
+
+# Mount as middleware
+Rails.application.middleware.use Dragonfly::Middleware
 
 # Add model functionality
 if defined?(ActiveRecord::Base)


### PR DESCRIPTION
This should allow you to use things like

```
@market.logo.thumb('200x200').url
```

and generate a cloudfront url that will load against the app and give you the image size you are looking for
