### PR TITLE
Fix for cross-sell delivery schedule selection

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -55,13 +55,16 @@ module Admin
     private
 
     def product_params
-      params.require(:product).permit(
+      results = params.require(:product).permit(
         :name, :image, :category_id, :unit_id, :location_id,
         :short_description, :long_description,
         :who_story, :how_story,
         :use_simple_inventory, :simple_inventory, :use_all_deliveries,
         delivery_schedule_ids: []
       )
+      
+      results.merge!(delivery_schedule_ids:[] ) unless results[:delivery_schedule_ids]
+      results
     end
 
     def after_create_page

--- a/spec/features/selling/edit_product_spec.rb
+++ b/spec/features/selling/edit_product_spec.rb
@@ -189,6 +189,19 @@ describe "Editing a product" do
         expect(Dom::Admin::ProductDelivery.find_by_weekday("Mondays")).to_not be_checked
         expect(Dom::Admin::ProductDelivery.find_by_weekday("Tuesdays")).to be_checked
       end
+
+      it "allows all delivery schedules to be unselected" do
+        uncheck "Make product available on all market delivery dates"
+
+        Dom::Admin::ProductDelivery.find_by_weekday("Mondays").uncheck!
+        Dom::Admin::ProductDelivery.find_by_weekday("Tuesdays").uncheck!
+
+        click_button "Save and Continue"
+        click_link "Product Info"
+
+        expect(Dom::Admin::ProductDelivery.find_by_weekday("Mondays")).to_not be_checked
+        expect(Dom::Admin::ProductDelivery.find_by_weekday("Tuesdays")).to_not be_checked
+      end
     end
 
     context 'multi-market membership' do
@@ -233,6 +246,21 @@ describe "Editing a product" do
 
         expect(Dom::Admin::ProductDelivery.find_by_weekday("Mondays")).to_not be_checked
         expect(Dom::Admin::ProductDelivery.find_by_weekday("Tuesdays")).to be_checked
+        expect(Dom::Admin::ProductDelivery.find_by_weekday("Wednesdays")).to_not be_checked
+      end
+
+      it "allows all delivery schedules to be unselected" do
+        uncheck "Make product available on all market delivery dates"
+
+        Dom::Admin::ProductDelivery.find_by_weekday("Mondays").uncheck!
+        Dom::Admin::ProductDelivery.find_by_weekday("Tuesdays").uncheck!
+        Dom::Admin::ProductDelivery.find_by_weekday("Wednesdays").uncheck!
+
+        click_button "Save and Continue"
+        click_link "Product Info"
+
+        expect(Dom::Admin::ProductDelivery.find_by_weekday("Mondays")).to_not be_checked
+        expect(Dom::Admin::ProductDelivery.find_by_weekday("Tuesdays")).to_not be_checked
         expect(Dom::Admin::ProductDelivery.find_by_weekday("Wednesdays")).to_not be_checked
       end
     end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -464,6 +464,16 @@ describe Product do
         it 'does not automatically add delivery schedules' do
           expect(product.delivery_schedules.count).to eql(0)
         end
+
+        it 'allows unselecting all delivery schedules' do
+          product.delivery_schedules = [monday_delivery]
+          expect(product.delivery_schedules.count).to eql(1)
+
+          product.delivery_schedule_ids = []
+          product.save
+
+          expect(product.reload.delivery_schedules.count).to eql(0)
+        end
       end
 
       context "multi-market membership" do
@@ -484,6 +494,16 @@ describe Product do
           expect(product.delivery_schedules.count).to eql(1)
           expect(product.delivery_schedules).to include(monday_delivery)
           expect(product.delivery_schedules).to_not include(wednesday_delivery)
+        end
+
+        it 'allows unselecting all delivery schedules' do
+          product.delivery_schedules = [monday_delivery, wednesday_delivery]
+          expect(product.delivery_schedules.count).to eql(2)
+
+          product.delivery_schedule_ids = []
+          product.save
+
+          expect(product.reload.delivery_schedules.count).to eql(0)
         end
       end
     end


### PR DESCRIPTION
The browser does not serialize an empty array to send to the server for delivery_schedule_ids.  We need that state to be valid in order to clear out all delivery schedules.
