### PR TITLE
Switch wysihtml5 parser rules to show colors

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,7 @@
 //= require jquery_ujs
 //= require jquery.ui.datepicker
 //= require chosen-jquery
-//= require parser_rules/simple
+//= require parser_rules/advanced
 //= require wysihtml5
 //= require underscore
 //= require accountingjs


### PR DESCRIPTION
They were getting stripped out, as explained here:
https://github.com/xing/wysihtml5/issues/194
[Fixes #59802024]
