### PR TITLE
Don't show account verification form to buyers

### DIFF
--- a/app/views/admin/bank_accounts/new.html.erb
+++ b/app/views/admin/bank_accounts/new.html.erb
@@ -83,7 +83,7 @@
 
 <%= form_for [:admin, @entity, @bank_account], html: { class: "column column--three-fourths" } do |f| %>
   <fieldset id="underwriting-fields" class="is-hidden" disabled>
-    <% unless @entity.balanced_underwritten? %>
+    <% unless @entity.balanced_underwritten? || current_user.buyer_only? %>
 
       <fieldset>
         <legend>Account Verification Information</legend>


### PR DESCRIPTION
This form is only shown for checking or savings account information when creating a payment method.  Hide it for buyers.

[Finishes: #71136054]
