### PR TITLE
Limit time shifting to during each test run

### DIFF
--- a/spec/features/buying/viewing_cart_spec.rb
+++ b/spec/features/buying/viewing_cart_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 describe "Viewing the cart", js: true do
+  before(:each) do
+    Timecop.travel("May 12, 2014")
+  end
+
   let!(:user) { create(:user) }
   let!(:buyer) { create(:organization, :single_location, :buyer, users: [user]) }
 
@@ -47,11 +51,7 @@ describe "Viewing the cart", js: true do
   let!(:cart_potatoes) { create(:cart_item, cart: cart, product: potatoes, quantity: 5) }
   let!(:cart_kale) { create(:cart_item, cart: cart, product: kale, quantity: 20) }
 
-  before(:all) do
-    Timecop.travel("May 12, 2014")
-  end
-
-  after(:all) do
+  after(:each) do
     Timecop.return
   end
 


### PR DESCRIPTION
I think weird things can happen when timecop persists outside the scope of an individual test.
Moving the before above the lets applies the before action before the lets.
