### PR TITLE
Ensure OrderItems show for Buyers by Order

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -52,7 +52,11 @@ class OrderItem < ActiveRecord::Base
   end
 
   def self.for_user(user)
-    joins(:product).where(products: {organization_id: user.managed_organizations.pluck(:id).uniq})
+    if user.buyer_only?
+      joins(:order).where(orders: { organization_id: user.managed_organizations.pluck(:id).uniq })
+    else
+      joins(:product).where(products: { organization_id: user.managed_organizations.pluck(:id).uniq })
+    end
   end
 
   def buyer_payment_status


### PR DESCRIPTION
Previously only showed OrderItems for Admins and/or Sellers

Fixes:
https://www.pivotaltracker.com/story/show/71437206
https://www.pivotaltracker.com/story/show/71437860
