### PR TITLE
Add specs for Zendesk mailer

### DIFF
--- a/spec/mailers/zendesk_mailer_spec.rb
+++ b/spec/mailers/zendesk_mailer_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe ZendeskMailer do
+  describe "request_unit" do
+    let(:email) { "requester@example.com" }
+    let(:name) { "Requester Person" }
+    let(:params) {{
+      singular: "fathom",
+      plural: "fathoms",
+      additional_notes: "See more notes"
+    }}
+
+    it "sends a new unit request to the admins" do
+      fresh_sheet = ZendeskMailer.request_unit(email, name, params)
+      expect(fresh_sheet.from).to include(email)
+      expect(fresh_sheet.body).to include(name)
+      expect(fresh_sheet.body).to include(params[:singular])
+      expect(fresh_sheet.body).to include(params[:plural])
+      expect(fresh_sheet.body).to include(params[:additional_notes])
+    end
+  end
+
+  describe "request_category" do
+    let(:email) { "requester@example.com" }
+    let(:name) { "Requester Person" }
+    let(:category) { "Meat/Spam" }
+
+    it "sends a new unit request to the admins" do
+      fresh_sheet = ZendeskMailer.request_category(email, name, category)
+      expect(fresh_sheet.from).to include(email)
+      expect(fresh_sheet.body).to include(name)
+      expect(fresh_sheet.body).to include(category)
+    end
+  end
+end


### PR DESCRIPTION
Zendesk emails broke over the weekend (https://www.honeybadger.io/inspector/p/34138/5774453) and we didn't have a smoke test to catch it. 

It was fixed via 4314441408325756228bbc004ba0b4fc215c2b0e where I renamed the templates from `.txt.erb` to `.text.erb`. I'm not sure how the former ever worked, but it did for a while. We need tests for these though!

/cc @pichot 
