### PR TITLE
Enable option for admins to choose a current_market when needed for show Market page

### DIFF
--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -1,5 +1,6 @@
 class MarketsController < ApplicationController
   before_action :hide_admin_navigation
+  before_action :require_selected_market
 
   def show
     @market = current_market.decorate


### PR DESCRIPTION
Previously no opt'ed if the current user was an admin when checking for
current_market. This caused issues when admin's viewed pages requiring
current_market and they did not have one (using next.localorbit.com or
app.localorbit.com directly).

Addresses: Tracker #69703396
