### PR TITLE
Install lograge for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,7 @@ group :production, :staging do
   gem 'pgbackups-archive'
   gem 'heroku-api'
 end
+
+group :production do
+  gem 'lograge'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,10 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.2)
       addressable (~> 2.3)
+    lograge (0.3.0)
+      actionpack (>= 3)
+      activesupport (>= 3)
+      railties (>= 3)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -424,6 +428,7 @@ DEPENDENCIES
   jquery-ui-rails
   kaminari
   launchy
+  lograge
   mysql2
   newrelic_rpm
   passenger

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,6 +78,7 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+  config.lograge.enabled = true
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
Lograge turns Rails logs into single-line output, vastly reducing log
output and making it easier to follow logs when there's more than one
application server.

Production was running into the free papertrail log limit, and this should give us quite a bit more room before we have to upgrade that service.

https://github.com/roidrage/lograge
