### PR TITLE
Fixes duplicate entries when filtering orders list for “Review Orders” view.

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -2,7 +2,7 @@ class Admin::OrdersController < AdminController
   def index
     @search_presenter = OrderSearchPresenter.new(request.query_parameters, current_user, "placed_at")
 
-    @q = Order.orders_for_seller(current_user).search(params[:q])
+    @q = Order.orders_for_seller(current_user).uniq.search(params[:q])
     @q.sorts = "placed_at desc" if @q.sorts.empty?
     @orders = @q.result.page(params[:page]).per(params[:per_page])
     @totals = OrderTotals.new(OrderItem.where(order_id: @q.result.map(&:id)))

--- a/spec/features/selling/viewing_orders_spec.rb
+++ b/spec/features/selling/viewing_orders_spec.rb
@@ -348,4 +348,32 @@ feature "Viewing orders" do
       expect(totals.net_sales).to eq("$32.43")
     end
   end
+
+  context "as an admin" do
+    let(:user){ create(:user, role: "admin")}
+
+    before do
+      switch_to_subdomain(market1.subdomain)
+      sign_in_as(user)
+    end
+
+
+    context "searching with an order number" do
+      it "only shows unique results" do
+        visit admin_orders_path
+
+        fill_in "Search Orders", with: market1_order1.order_number
+        click_button "Search"
+
+        items = Dom::Dashboard::OrderRow.all
+        expect(items.count).to eql(1)
+
+        fill_in "Search Orders", with: market1_order2.order_number
+        click_button "Search"
+
+        items = Dom::Dashboard::OrderRow.all
+        expect(items.count).to eql(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Fixes #73345644]
