### PR TITLE
Include items from deleted organizations in delivery lists

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -51,15 +51,15 @@ class OrderItem < ActiveRecord::Base
   end
 
   def self.for_delivery_and_user(delivery, user)
-    ids = user.managed_organizations.map(&:id)
+    ids = user.managed_organization_ids_including_deleted
     OrderItem.for_delivery(delivery).joins(:product).where(products: {organization_id: ids})
   end
 
   def self.for_user(user)
     if user.buyer_only?
-      joins(:order).where(orders: { organization_id: user.managed_organizations_including_deleted.pluck(:id).uniq })
+      joins(:order).where(orders: { organization_id: user.managed_organization_ids_including_deleted })
     else
-      joins(:product).where(products: { organization_id: user.managed_organizations_including_deleted.pluck(:id).uniq })
+      joins(:product).where(products: { organization_id: user.managed_organization_ids_including_deleted })
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,6 +113,10 @@ class User < ActiveRecord::Base
     end
   end
 
+  def managed_organization_ids_including_deleted
+    managed_organizations_including_deleted.pluck(:id).uniq
+  end
+
   def managed_organizations_within_market(market)
     if admin? || managed_markets.include?(market)
       market.organizations

--- a/app/presenters/seller_order.rb
+++ b/app/presenters/seller_order.rb
@@ -8,7 +8,7 @@ class SellerOrder
   def initialize(order, seller)
     @order = order.decorate
     if seller.is_a?(User)
-      @items = order.items.select("order_items.*").joins(:product).where("products.organization_id" => seller.managed_organizations_including_deleted.pluck(:id)).order('order_items.name')
+      @items = order.items.select("order_items.*").joins(:product).where("products.organization_id" => seller.managed_organization_ids_including_deleted).order('order_items.name')
     elsif seller.is_a?(Organization)
       @items = order.items.select("order_items.*").joins(:product).where("products.organization_id" => seller.id).order('order_items.name')
     end

--- a/spec/features/selling/view_order_summary_spec.rb
+++ b/spec/features/selling/view_order_summary_spec.rb
@@ -83,6 +83,14 @@ describe "Order summary" do
         visit admin_delivery_tools_order_summary_path(friday_delivery.id)
         see_orders_for_entire_market
       end
+
+      it "includes items from deleted organizations" do
+        MarketOrganization.where(organization_id: sellers.id, market_id: market.id).soft_delete
+        switch_to_subdomain(market.subdomain)
+        sign_in_as(market_manager)
+        navigate_to_order_summary
+        see_orders_for_entire_market
+      end
     end
 
     context "as an admin" do


### PR DESCRIPTION
The `OrderItem.for_user` method included them, so it seems we should in the `.for_delivery_and_user` method as well.
