### PR TITLE
Admin viewing products after deleting an organization

### DIFF
--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -6,7 +6,7 @@ module Admin
     end
 
     def create
-      market = current_market || @organization.markets.first
+      market = current_market || @organization.original_market
       @invite_user = InviteUserToOrganization.perform(
         inviter: current_user,
         email: user_params[:email],

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -53,7 +53,7 @@ module Admin
                     @organization.markets.managed_by(current_user).where(id: params[:ids])
                   end
                 else
-                  @organization.markets.managed_by(current_user).where(id: @organization.markets.first.id)
+                  @organization.markets.managed_by(current_user).where(id: @organization.original_market.id)
                 end
 
       postfix = if markets.count == 1

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -87,6 +87,10 @@ class Organization < ActiveRecord::Base
     Balanced::Customer.find(balanced_customer_uri)
   end
 
+  def original_market
+    (markets.empty? ? cross_sells : markets).first
+  end
+
   private
 
   def self.order_by_name(direction)

--- a/app/models/price.rb
+++ b/app/models/price.rb
@@ -20,7 +20,7 @@ class Price < ActiveRecord::Base
   end
 
   def net_percent
-    (market || product.organization.markets.first).seller_net_percent
+    (market || product.organization.original_market).seller_net_percent
   end
 
   def for_market_and_organization?(market, organization)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -156,11 +156,11 @@ class Product < ActiveRecord::Base
   end
 
   def market_name
-    organization.markets.first.name
+    organization.original_market.name
   end
 
   def net_percent
-    organization.markets.first.seller_net_percent
+    organization.original_market.seller_net_percent
   end
 
   def organization_name

--- a/app/views/admin/products/index.html.erb
+++ b/app/views/admin/products/index.html.erb
@@ -21,7 +21,7 @@
     <% @products.decorate.each do |product| %>
       <tr class="product-row <%= cycle "odd", "even" %>">
         <%= content_tag(:td, link_to(product.organization_name, [:admin, product.organization]), class: 'seller hidden-mobile') if current_user.multi_organization_membership? %>
-        <%= content_tag(:td, link_to(product.market_name, [:admin, product.organization.markets.first]), class: 'market hidden-mobile') if current_user.multi_market_membership? %>
+        <%= content_tag(:td, link_to(product.market_name, [:admin, product.organization.original_market]), class: 'market hidden-mobile') if current_user.multi_market_membership? %>
         <td class="name product-name"><%= link_to product.name_and_unit, [:admin, product] %></td>
         <td class="pricing">
           <ul class="l-inline-list">

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,7 +1,7 @@
 <%# gets the market for the email layout. Isn't ideal, but works well. %>
 <% if organization = @resource.organizations.first
      org_or_market_name = organization.name
-     @market = organization.markets.first
+     @market = organization.original_market
    elsif @market = @resource.primary_market
      org_or_market_name = @market.name
    else


### PR DESCRIPTION
Fixes problems w/ market manager viewing /admin/products after deleting an organization from 
all markets except for a cross-selling relationship.
