### PR TITLE
Correct redirect path after market payments

### DIFF
--- a/app/controllers/admin/financials/market_payments_controller.rb
+++ b/app/controllers/admin/financials/market_payments_controller.rb
@@ -9,9 +9,9 @@ module Admin::Financials
     def create
       @pay_market = PayMarketForOrders.perform(user: current_user, market_id: params[:market_id], bank_account_id: params[:bank_account_id], order_ids: params[:order_ids])
       if @pay_market.success?
-        redirect_to :index, notice: "Payment recorded"
+        redirect_to admin_financials_market_payments_path, notice: "Payment recorded"
       else
-        redirect_to :index, alert: "Payment failed"
+        redirect_to admin_financials_market_payments_path, alert: "Payment failed"
       end
     end
   end


### PR DESCRIPTION
Currently an us only thing. Not linked anywhere
[ci skip]
