### PR TITLE
Better nested resource handling for highlighted tabs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,7 +57,7 @@ module ApplicationHelper
   end
 
   def link_to_or_span(name, options={}, html_options={}, &block)
-    if similar_base_url_for_tab?(options)
+    if similar_base_url_for_tab?(url_for, options)
       if html_options[:class].present?
         html_options[:class] += " current"
       else
@@ -71,10 +71,10 @@ module ApplicationHelper
 
   # a matcher similar to current_page?(options) but crazier!
   # See also http://rubular.com/r/PVc6MLd5mL
-  def similar_base_url_for_tab?(options)
-    base_url = url_for.sub(/\/?(\d*|new)?(\?.*)?$/, "")
+  def similar_base_url_for_tab?(current_url, options)
+    base_url = current_url.sub(/\/?(\d+(\/edit)?|new|)?(\?.*)?$/, "")
     regexp = %r{#{Regexp.escape(base_url)}(/(new|\d+(/edit)?)|)$}
-    regexp =~ url_for(options)
+    !!(regexp =~ url_for(options))
   end
 
   def background_options

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -29,4 +29,33 @@ describe ApplicationHelper do
       expect(color_mix("#456589", 50)).to eq("hsl(211, 33%, 90%)")
     end
   end
+  
+  describe "#similar_base_url_for_tab?" do        
+    data = [
+      ["/admin/markets", "/admin/markets/", true],
+      ["/admin/markets", "/admin/markets/new", true],
+      ["/admin/markets", "/admin/markets/5", true],
+      ["/admin/markets", "/admin/markets/5/edit", true],
+      ["/admin/markets", "/admin/markets/5/addresses", false],
+      ["/admin/markets/5/addresses", "/admin/markets/5/addresses", true],
+      ["/admin/markets/5/addresses", "/admin/markets/5/addresses/new", true],
+      ["/admin/markets/5/addresses", "/admin/markets/5/addresses/7", true],
+      ["/admin/markets/5/addresses", "/admin/markets/5/addresses/7/edit", true],
+      ["/admin/markets/5/addresses", "/admin/markets/5/bank_accounts", false],
+      ["/admin/markets/5/addresses", "/admin/markets/5/bank_accounts/new", false],
+      ["/admin/markets/5/addresses", "/admin/markets/5/bank_accounts/9", false],
+      ["/admin/markets/5/addresses", "/admin/markets/5/bank_accounts/9/edit", false],
+      ["/admin/financials/receipts", "/admin/financials/receipts", true],
+      ["/admin/financials/receipts", "/admin/financials/receipts/new", true],
+      ["/admin/financials/receipts", "/admin/financials/receipts/11", true],
+      ["/admin/financials/receipts", "/admin/financials/receipts/11/edit", true],
+    ]
+    
+    data.each do |tab_url, current_url, expectation|
+      it "#{(expectation ? "highlights" : "doesn't highlight")} tab #{tab_url} for url #{current_url}" do
+        expect(similar_base_url_for_tab?(current_url, tab_url)).to eq(expectation)
+      end
+    end
+    
+  end
 end


### PR DESCRIPTION
Add test cases for some interesting logic that handles when to set a
tab as the currently selected tab. Should fix issues when editing
deliveries, addresses, and receipts.

[Finishes #74873292]
