### PR TITLE
Reduce width of data-tools

### DIFF
--- a/app/assets/stylesheets/modules-base.css.scss
+++ b/app/assets/stylesheets/modules-base.css.scss
@@ -1098,7 +1098,7 @@
   }
   &[data-tools="4"] {
     > .tool {
-      width: 24.9%;
+      width: 23.9%;
     }
   }
   &[data-tools="3"] {


### PR DESCRIPTION
The 24.9% was causing the tab like tools to wrap for market managers and admin users.

Sellers only see three "tabs" and are unaffected by this change.

[ci-skip]
