### PR TITLE
Remove production flag from credit card form

### DIFF
--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -99,7 +99,6 @@
                         Add a <%= link_to "credit card", new_admin_organization_bank_account_path(current_organization) %> to your account.
                       <% end %><br>
 
-                      <% unless Rails.env.production? %>
                       <label>New Credit Card</label><br>
                       <fieldset id="balanced-payments-uri" data-balanced-marketplace-uri="<%= ENV["BALANCED_MARKETPLACE_URI"] %>">
                         <div class="row">
@@ -137,7 +136,6 @@
                           </div>
                         </div>
                       </fieldset>
-                      <% end %>
                     </div>
                   </fieldset>
                 </div>


### PR DESCRIPTION
[Fixes #75393248]

The credit card field was being omitted form the production environment until it had stabilized.  Enabling it now.
