### PR TITLE
Improve the fees calculations for an Order

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -290,19 +290,19 @@ class Order < ActiveRecord::Base
   end
 
   def payable_subtotal
-    @payable_subtotal ||= items.to_a.inject(delivery_fees) {|sum, item| sum + (item.delivered? ? item.gross_total : 0) }
+    @payable_subtotal ||= delivery_fees + items.delivered.to_a.sum {|i| i.gross_total }
   end
 
   def market_payable_market_fee
-    @market_payable_market_fee ||= items.to_a.sum {|i| i.delivered? ? i.market_seller_fee : 0 }
+    @market_payable_market_fee ||= items.delivered.sum(:market_seller_fee)
   end
 
   def market_payable_local_orbit_fee
-    @market_payable_local_orbit_fee ||= items.to_a.sum {|i| i.delivered? ? i.local_orbit_seller_fee + i.local_orbit_market_fee : 0 }
+    @market_payable_local_orbit_fee ||= items.delivered.sum("local_orbit_seller_fee + local_orbit_market_fee")
   end
 
   def market_payable_payment_fee
-    @market_payable_payment_fee ||= items.to_a.sum {|i| i.delivered? ? i.payment_seller_fee + i.payment_market_fee : 0 }
+    @market_payable_payment_fee ||= items.delivered.sum("payment_seller_fee + payment_market_fee")
   end
 
   def apply_delivery_address(address)

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -26,6 +26,7 @@ class OrderItem < ActiveRecord::Base
   before_save :update_delivered_at
   before_save :update_consumed_inventory
 
+  scope :delivered,    -> { where(delivery_status: "delivered") }
   scope :undelivered,  -> { where(delivery_status: "pending") }
 
   def self.for_delivery(delivery)

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -570,12 +570,12 @@ describe Order do
   end
 
   describe "payable to market" do
-    let(:order_item1) { build(:order_item, delivery_status: "pending",   unit_price: "12.23", quantity: 1, market_seller_fee: "2.10", local_orbit_seller_fee: "3.20", local_orbit_market_fee: "2.40", payment_seller_fee: "1.30", payment_market_fee: "0.20") }
-    let(:order_item2) { build(:order_item, delivery_status: "canceled",  unit_price: "17.13", quantity: 2, market_seller_fee: "0.00", local_orbit_seller_fee: "0.00", local_orbit_market_fee: "0.00", payment_seller_fee: "0.00", payment_market_fee: "0.00") }
-    let(:order_item3) { build(:order_item, delivery_status: "delivered", unit_price: "13.27", quantity: 4, market_seller_fee: "3.87", local_orbit_seller_fee: "4.39", local_orbit_market_fee: "3.76", payment_seller_fee: "2.32", payment_market_fee: "1.30") }
-    let(:order_item4) { build(:order_item, delivery_status: "contested", unit_price: "14.75", quantity: 2, market_seller_fee: "1.56", local_orbit_seller_fee: "2.80", local_orbit_market_fee: "3.10", payment_seller_fee: "2.10", payment_market_fee: "1.50") }
-    let(:order_item5) { build(:order_item, delivery_status: "delivered", unit_price: "10.83", quantity: 3, market_seller_fee: "2.87", local_orbit_seller_fee: "3.39", local_orbit_market_fee: "2.76", payment_seller_fee: "1.32", payment_market_fee: "0.30") }
-    let(:order) { build(:order, delivery_fees: "11", total_cost: "138.30", items: [order_item1, order_item2, order_item3, order_item4, order_item5]) }
+    let(:order_item1) { create(:order_item, delivery_status: "pending",   unit_price: "12.23", quantity: 1, market_seller_fee: "2.10", local_orbit_seller_fee: "3.20", local_orbit_market_fee: "2.40", payment_seller_fee: "1.30", payment_market_fee: "0.20") }
+    let(:order_item2) { create(:order_item, delivery_status: "canceled",  unit_price: "17.13", quantity: 2, market_seller_fee: "0.00", local_orbit_seller_fee: "0.00", local_orbit_market_fee: "0.00", payment_seller_fee: "0.00", payment_market_fee: "0.00") }
+    let(:order_item3) { create(:order_item, delivery_status: "delivered", unit_price: "13.27", quantity: 4, market_seller_fee: "3.87", local_orbit_seller_fee: "4.39", local_orbit_market_fee: "3.76", payment_seller_fee: "2.32", payment_market_fee: "1.30") }
+    let(:order_item4) { create(:order_item, delivery_status: "contested", unit_price: "14.75", quantity: 2, market_seller_fee: "1.56", local_orbit_seller_fee: "2.80", local_orbit_market_fee: "3.10", payment_seller_fee: "2.10", payment_market_fee: "1.50") }
+    let(:order_item5) { create(:order_item, delivery_status: "delivered", unit_price: "10.83", quantity: 3, market_seller_fee: "2.87", local_orbit_seller_fee: "3.39", local_orbit_market_fee: "2.76", payment_seller_fee: "1.32", payment_market_fee: "0.30") }
+    let(:order) { create(:order, delivery_fees: "11", total_cost: "138.30", items: [order_item1, order_item2, order_item3, order_item4, order_item5]) }
 
     it "payable_to_market returns the appropriate value" do
       # delivered item subtotal + delivery fee - local orbit fees - payment fees


### PR DESCRIPTION
As every one of these methods first checked for #delivered? and are just
straight sums of database columns, we can drop to the database for
everything.
