### PR TITLE
Restrict discounts usage count

### DIFF
--- a/app/interactors/apply_discount_to_cart.rb
+++ b/app/interactors/apply_discount_to_cart.rb
@@ -17,6 +17,14 @@ class ApplyDiscountToCart
   end
 
   def can_use_discount?(discount)
-    discount.maximum_uses == 0 || discount.maximum_uses < discount.total_uses
+    less_than_max_uses?(discount) && less_than_max_org_uses?(discount)
+  end
+
+  def less_than_max_uses?(discount)
+    discount.maximum_uses == 0 || discount.maximum_uses > discount.total_uses
+  end
+
+  def less_than_max_org_uses?(discount)
+    discount.maximum_organization_uses == 0 || discount.maximum_organization_uses > discount.uses_by_organization(cart.organization)
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -78,6 +78,8 @@ FactoryGirl.define do
     sequence(:code) {|n| n.to_s(16) }
     type "fixed"
     discount 5.00
+    maximum_uses 0
+    maximum_organization_uses 0
   end
 
   factory :location do

--- a/spec/features/buying/viewing_cart_spec.rb
+++ b/spec/features/buying/viewing_cart_spec.rb
@@ -377,10 +377,26 @@ describe "Viewing the cart", :js do
       end
     end
 
-    context "with a valid discount maxed out on usage" do
+    context "with a valid discount maxed out on total usage" do
       let!(:discount) { create(:discount, code: "15off", discount: "15", type: "fixed", maximum_uses: 2) }
       let!(:order1) { create(:order, discount: discount )}
       let!(:order2) { create(:order, discount: discount )}
+
+      it "informs the user the code has expired" do
+        fill_in "Discount Code", with: "15off"
+        click_link "Apply"
+
+        expect(page).to have_content("Discount code expired")
+
+        within("#totals") do
+          expect(page).not_to have_content("Discount")
+        end
+      end
+    end
+
+    context "with a valid discount maxed out on organizational usage" do
+      let!(:discount) { create(:discount, code: "15off", discount: "15", type: "fixed", maximum_organization_uses: 1) }
+      let!(:order1)   { create(:order, organization: buyer, discount: discount )}
 
       it "informs the user the code has expired" do
         fill_in "Discount Code", with: "15off"


### PR DESCRIPTION
- [x] Restrict the maximum times a discount code can be used.
- [x] Restrict the maximum times an organization can use a discount code.
