### PR TITLE
Add a spec for setting cart quantities to 0

### DIFF
--- a/spec/features/buying/removing_items_from_cart_spec.rb
+++ b/spec/features/buying/removing_items_from_cart_spec.rb
@@ -136,6 +136,11 @@ describe "Removing items" do
     end
 
     it "by setting the quantity to 0" do
+      kale_item.set_quantity(0)
+      expect(Dom::CartLink.first).to have_content("Removed from cart!")
+
+      expect(kale_item.quantity_field.value).to eq("0")
+      expect(cart_link.count).to have_content("2")
     end
   end
 end


### PR DESCRIPTION
Trying to track down [this](https://www.honeybadger.io/inspector/p/34138/7514555/10) issue that keeps creeping up... but I can't get it to reproduce locally even with Audited enabled when running the tests. That said, this is still a useful test case to have.
