### PR TITLE
Exclude organizations without markets from the user management screen

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -37,6 +37,7 @@ class Organization < ActiveRecord::Base
   scope :visible, -> { where(show_profile: true) }
   scope :with_products, -> { joins(:products).select("DISTINCT organizations.*").order(name: :asc) }
   scope :buyers_for_orders, lambda {|orders| joins(:orders).where(orders: {id: orders}).uniq }
+  scope :with_a_market, -> { joins(user_organizations:{organization: :markets}).group("organizations.id") }
 
   serialize :twitter, TwitterUser
 

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -39,13 +39,12 @@
           <td>Market Manager</td>
         </tr>
       <% end %>
-
-      <% @user.organizations.each do |organization| %>
-      <tr>
-        <td><%= organization.markets.pluck(:name).to_sentence %></td>
-        <td><%= organization.name %></td>
-        <td><%= organization.can_sell? ? "Seller" : "Buyer" %></td>
-      </tr>
+      <% @user.organizations.with_a_market.each do |organization| %>
+        <tr>
+          <td><%= organization.markets.pluck(:name).to_sentence %></td>
+          <td><%= organization.name %></td>
+          <td><%= organization.can_sell? ? "Seller" : "Buyer" %></td>
+        </tr>
       <% end %>
     </table>
   </div>


### PR DESCRIPTION
[Fixes #76892194]
