### PR TITLE
Add Request UUID to audits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,8 @@ gem 'wysihtml5-rails'
 gem "active_model_serializers"
 gem "active_record_union"
 gem "acts_as_geocodable", github: 'collectiveidea/acts_as_geocodable'
-gem "audited-activerecord", "~> 4.0.0.rc1"
+gem "audited", github: 'collectiveidea/audited', branch: 'request-uuid'
+gem "audited-activerecord", github: 'collectiveidea/audited', branch: 'request-uuid'
 gem "awesome_nested_set"
 gem "balanced", "~> 0.7"
 gem "color"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,17 @@ GIT
       rails (>= 3, < 4.2)
 
 GIT
+  remote: git://github.com/collectiveidea/audited.git
+  revision: 30033b5fa98f2e4936df286ca3655acfab0f8c2e
+  branch: request-uuid
+  specs:
+    audited (4.0.0.rc1)
+      rails-observers (~> 0.1.2)
+    audited-activerecord (4.0.0.rc1)
+      activerecord (~> 4.0)
+      audited (= 4.0.0.rc1)
+
+GIT
   remote: git://github.com/collectiveidea/delayed_job.git
   revision: 6fc9000bc0e1e56d0781468ccdddcd61e6d5b7ae
   specs:
@@ -80,11 +91,6 @@ GEM
     addressable (2.3.6)
     arel (5.0.1.20140414130214)
     ast (2.0.0)
-    audited (4.0.0.rc1)
-      rails-observers (~> 0.1.2)
-    audited-activerecord (4.0.0.rc1)
-      activerecord (~> 4.0)
-      audited (= 4.0.0.rc1)
     awesome_nested_set (3.0.0)
       activerecord (>= 4.0.0, < 5)
     balanced (0.8.2)
@@ -429,7 +435,8 @@ DEPENDENCIES
   active_model_serializers
   active_record_union
   acts_as_geocodable!
-  audited-activerecord (~> 4.0.0.rc1)
+  audited!
+  audited-activerecord!
   awesome_nested_set
   balanced (~> 0.7)
   capybara

--- a/db/migrate/20140814161020_add_request_uuid_to_audits.rb
+++ b/db/migrate/20140814161020_add_request_uuid_to_audits.rb
@@ -1,0 +1,10 @@
+class AddRequestUuidToAudits < ActiveRecord::Migration
+  def self.up
+    add_column :audits, :request_uuid, :string
+    add_index :audits, :request_uuid
+  end
+
+  def self.down
+    remove_column :audits, :request_uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140814144651) do
+ActiveRecord::Schema.define(version: 20140814161020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,11 +30,13 @@ ActiveRecord::Schema.define(version: 20140814144651) do
     t.string   "comment"
     t.string   "remote_address"
     t.datetime "created_at"
+    t.string   "request_uuid"
   end
 
   add_index "audits", ["associated_id", "associated_type"], name: "associated_index", using: :btree
   add_index "audits", ["auditable_id", "auditable_type"], name: "auditable_index", using: :btree
   add_index "audits", ["created_at"], name: "index_audits_on_created_at", using: :btree
+  add_index "audits", ["request_uuid"], name: "index_audits_on_request_uuid", using: :btree
   add_index "audits", ["user_id", "user_type"], name: "user_index", using: :btree
 
   create_table "bank_accounts", force: true do |t|
@@ -567,8 +569,8 @@ ActiveRecord::Schema.define(version: 20140814144651) do
     t.integer  "location_id"
     t.boolean  "use_simple_inventory",     default: true, null: false
     t.integer  "unit_id"
-    t.integer  "top_level_category_id"
     t.string   "image_uid"
+    t.integer  "top_level_category_id"
     t.datetime "deleted_at"
     t.text     "short_description"
     t.text     "long_description"


### PR DESCRIPTION
Every request will have the same UUID to make it easier
to track audits that should be grouped.
