### PR TITLE
Use appears on statement as and payment meta data

### DIFF
--- a/app/interactors/attempt_balanced_purchase.rb
+++ b/app/interactors/attempt_balanced_purchase.rb
@@ -54,7 +54,9 @@ class AttemptBalancedPurchase
     cart.organization.balanced_customer.debit(
       amount: amount,
       source_uri: bank_account.balanced_uri,
-      description: "#{cart.market.name} purchase"
+      description: "#{cart.market.name} purchase",
+      appears_on_statement_as: cart.market.on_statement_as,
+      meta: {'order number' => order.order_number}
     ) if amount > 0
   end
 

--- a/app/interactors/update_balanced_purchase.rb
+++ b/app/interactors/update_balanced_purchase.rb
@@ -64,7 +64,9 @@ class UpdateBalancedPurchase
     new_debit = account.bankable.balanced_customer.debit(
       amount: amount_to_cents(amount),
       source_uri: account.balanced_uri,
-      description: "#{order.market.name} purchase"
+      description: "#{order.market.name} purchase",
+      appears_on_statement_as: order.market.on_statement_as,
+      meta: {'order number' => order.order_number}
     )
     context[:status] = "paid"
 

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -130,6 +130,10 @@ class Market < ActiveRecord::Base
     (plan_interval * plan_payments.count).months.from_now(plan_start_at)
   end
 
+  def on_statement_as
+    name.sub(/[^0-9a-zA-Z\.\-_ \^\`\|]/, '')[0, 22]
+  end
+
   private
 
   def require_payment_method

--- a/payments_to_be_made.rb
+++ b/payments_to_be_made.rb
@@ -45,7 +45,7 @@ groups.each do |group|
   balanced_account = Balanced::BankAccount.find(bank_account.balanced_uri)
   credit = balanced_account.credit(
     amount: (p.amount * 100).to_i,
-    appears_on_statement_as: p.market.name[0, 22]
+    appears_on_statement_as: p.market.on_statement_as
   )
   p.update_column(:balanced_uri, credit.uri)
 end; nil

--- a/spec/interactors/attempt_balanced_purchase_spec.rb
+++ b/spec/interactors/attempt_balanced_purchase_spec.rb
@@ -82,7 +82,9 @@ describe AttemptBalancedPurchase do
           expect(balanced_customer).to have_received(:debit).with(
             amount: (cart.total*100).to_i,
             source_uri: bank_account.balanced_uri,
-            description: "#{cart.market.name} purchase"
+            description: "#{cart.market.name} purchase",
+            appears_on_statement_as: market.name,
+            meta: {"order number" => order.order_number}
           )
         end
       end
@@ -211,7 +213,13 @@ describe AttemptBalancedPurchase do
 
         it "creates a hold for the order amount" do
           expect(subject).to be_success
-          expect(balanced_customer).to have_received(:debit).with(amount: (cart.total*100).to_i, description: "#{market.name} purchase", source_uri: credit_card.balanced_uri)
+          expect(balanced_customer).to have_received(:debit).with(
+            amount: (cart.total*100).to_i,
+            source_uri: credit_card.balanced_uri,
+            description: "#{market.name} purchase",
+            appears_on_statement_as: market.name,
+            meta: {"order number" => order.order_number}
+          )
         end
       end
 

--- a/spec/interactors/update_balanced_purchase_spec.rb
+++ b/spec/interactors/update_balanced_purchase_spec.rb
@@ -172,7 +172,7 @@ describe UpdateBalancedPurchase do
 
       it "charges the difference when the order amount goes up" do
         expect(Balanced::Customer).to receive(:find).with('/balanced-account-uri').and_return(balanced_customer)
-        expect(balanced_customer).to receive(:debit).with({amount: 1500, source_uri: '/balanced-card-uri', description: "#{market.name} purchase"})
+        expect(balanced_customer).to receive(:debit).with({amount: 1500, source_uri: '/balanced-card-uri', description: "#{market.name} purchase", appears_on_statement_as: market.name, meta: {"order number" => order.order_number}})
 
         expect(order.reload.payments.count).to eql(1)
 
@@ -263,7 +263,7 @@ describe UpdateBalancedPurchase do
 
       it "charges the difference when the order amount goes up" do
         expect(Balanced::Customer).to receive(:find).with('/balanced-account-uri').and_return(balanced_customer)
-        expect(balanced_customer).to receive(:debit).with({amount: 1500, source_uri: '/balanced-bank-account-uri', description: "#{market.name} purchase"})
+        expect(balanced_customer).to receive(:debit).with({amount: 1500, source_uri: '/balanced-bank-account-uri', description: "#{market.name} purchase", appears_on_statement_as: market.name, meta: {"order number" => order.order_number}})
 
         expect(order.reload.payments.count).to eql(1)
 


### PR DESCRIPTION
Appears on statement as makes things clearer for the buyer

Adding order number to the payment meta data makes looking things up from balanced easier for us.
