### PR TITLE
Include rails url helpers in market map serializer

### DIFF
--- a/app/serializers/market_map_serializer.rb
+++ b/app/serializers/market_map_serializer.rb
@@ -1,4 +1,6 @@
 class MarketMapSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+
   attributes :id, :name, :latitude, :longitude, :plan_name, :market_path
 
   def latitude


### PR DESCRIPTION
active_model_serializers version 0.9.0 seemed to have changed how it works with url helpers.

This is a cleaner approach than #1247. I'll be closing that in favor of this.
