### PR TITLE
Fix PDF asset path generation on staging and production

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,11 @@ module ApplicationHelper
     end
   end
 
+  def pdf_asset_path(asset)
+    path = Rails.env.development? ? Figaro.env.asset_host : ""
+    path += asset_path(asset)
+  end
+
   # Used in navigation to get to the users organization(s)
   def link_to_my_organization
     org_count = current_user.managed_organizations(include_suspended: true).count

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -13,8 +13,8 @@
   <%= render 'shared/print_opensans' %>
   <%= render 'shared/print_opensans_bold' %>
 
-  <link href="<%= Figaro.env.asset_host %><%= asset_path('invoices.css') %>" rel="stylesheet">
-  <link href="<%= Figaro.env.asset_host %><%= asset_path('z-sniff.css') %>" rel="stylesheet">
+  <link href="<%= pdf_asset_path('invoices.css') %>" rel="stylesheet">
+  <link href="<%= pdf_asset_path('z-sniff.css') %>" rel="stylesheet">
 </head>
 
 <body class="controller-invoices">


### PR DESCRIPTION
asset_path isn't playing nice when generating PDFs on development and test.  This should fix it from braking on production and staging.
