### PR TITLE
Fixes bug with admins viewing orders

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,6 +50,8 @@ class ApplicationController < ActionController::Base
   end
 
   def find_current_organization
+    return nil unless current_market
+
     current_user.managed_organizations_within_market(current_market)
     organization = if current_user.managed_organizations.count == 1
       current_user.managed_organizations.first


### PR DESCRIPTION
When current market is nil (admin user in certain cases) finding current organization would blow up.  Return nil in this special case fixes the issue.
