### PR TITLE
Clear the invoice pdf when an order is updated

### DIFF
--- a/app/interactors/clear_invoice_pdf.rb
+++ b/app/interactors/clear_invoice_pdf.rb
@@ -1,0 +1,9 @@
+class ClearInvoicePdf
+  include Interactor
+
+  def perform
+    if order
+      order.update(invoice_pdf: nil)
+    end
+  end
+end

--- a/app/interactors/update_order.rb
+++ b/app/interactors/update_order.rb
@@ -1,5 +1,5 @@
 class UpdateOrder
   include Interactor::Organizer
 
-  organize UpdateQuantities, StoreOrderFees, UpdateBalancedPurchase, SendUpdateEmails
+  organize UpdateQuantities, StoreOrderFees, UpdateBalancedPurchase, SendUpdateEmails, ClearInvoicePdf
 end

--- a/spec/features/selling/edit_order_spec.rb
+++ b/spec/features/selling/edit_order_spec.rb
@@ -440,6 +440,12 @@ describe "Editing an order" do
 
           expect(Dom::Order::ItemRow.first.delivery_status).to eql("Delivered")
         end
+
+        it "clears the orders invoice pdf if it has one" do
+          expect(ClearInvoicePdf).to receive(:perform)
+
+          subject
+        end
       end
 
       context "more then ordered" do
@@ -492,6 +498,12 @@ describe "Editing an order" do
           subject
 
           expect(Dom::Order::ItemRow.first.delivery_status).to eql("Delivered")
+        end
+
+        it "clears the orders invoice pdf if it has one" do
+          expect(ClearInvoicePdf).to receive(:perform)
+
+          subject
         end
       end
 
@@ -604,6 +616,12 @@ describe "Editing an order" do
 
           expect(Dom::Order::ItemRow.first.delivery_status).to eql("Delivered")
         end
+
+        it "clears the orders invoice pdf if it has one" do
+          expect(ClearInvoicePdf).to receive(:perform)
+
+          subject
+        end
       end
 
       context "more then ordered" do
@@ -656,6 +674,12 @@ describe "Editing an order" do
           subject
 
           expect(Dom::Order::ItemRow.first.delivery_status).to eql("Delivered")
+        end
+
+        it "clears the orders invoice pdf if it has one" do
+          expect(ClearInvoicePdf).to receive(:perform)
+
+          subject
         end
       end
 


### PR DESCRIPTION
If a user goes to look at the invoice pdf after changing an invoice, we need to re-generate it in order for it to be correct.  This PR clears the invoice pdf so that it will be regenerated.
