### PR TITLE
Buyers can now view Orders from Payment History, and don't need to select a Delivery first.

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,8 +2,8 @@ class OrdersController < ApplicationController
   before_action :require_selected_market
   before_action :require_market_open
   before_action :require_current_organization
-  before_action :require_organization_location
-  before_action :require_current_delivery
+  before_action :require_organization_location, except: [:show]
+  before_action :require_current_delivery, except: [:show]
   before_action :require_cart
   before_action :hide_admin_navigation
 

--- a/app/views/admin/financials/payments/index.html.erb
+++ b/app/views/admin/financials/payments/index.html.erb
@@ -33,7 +33,8 @@
           <td class="date"><%= payment.created_at.strftime("%m/%d/%Y") %></td>
           <td class="description">
             <% if payment.payment_type == "order" || payment.payment_type == "seller payment" || payment.payment_type == "market payment" %>
-              Order #: <%= link_to payment.orders.first.order_number, admin_order_path(payment.orders.first) %>
+              <%- order_link_path = current_user.buyer_only? ? order_path(payment.orders.first) : admin_order_path(payment.orders.first) %>
+              Order #: <%= link_to payment.orders.first.order_number, order_link_path %>
               <% if payment.orders.count > 1 %>
                 <%= link_to raw('<i class="font-icon icon-plus-circle"> </i>'), "#more-info-#{payment.id}", class:"modal-toggle more-info payment-more", data: { modal: "more-info-#{payment.id}"} %>
 

--- a/spec/features/buying/viewing_dashboard_spec.rb
+++ b/spec/features/buying/viewing_dashboard_spec.rb
@@ -67,6 +67,24 @@ describe "Buyer viewing dashboard" do
       expect(order.payment_status).to eq("Unpaid")
       expect(order.total).to eq("$#{order3.total_cost}")
     end
+
+    it "lets them open their Orders" do
+      switch_to_subdomain(market.subdomain)
+      sign_in_as(user)
+      click_link "Dashboard", match: :first
+
+      orders = Dom::Dashboard::OrderRow.all
+      expect(orders.size).to eq(3)
+      hist_order = orders[0]
+
+      click_link hist_order.order_number
+
+      expect(page).not_to have_content("Please choose a pick up")
+
+      expect(page).to have_content("Order info for #{hist_order.order_number}")
+      expect(page).to have_content("Payment Method:")
+      expect(page).to have_content("Delivery Status:")
+    end
   end
 
   context "without orders" do


### PR DESCRIPTION
Fixes #78823306:
- Delivery selection not required to view existing Orders as a Buyer
- Using the correct links to Orders in Payment History
