### PR TITLE
Make sure checkboxes stay checked for correct data

### DIFF
--- a/app/views/admin/market_addresses/edit.html.erb
+++ b/app/views/admin/market_addresses/edit.html.erb
@@ -8,12 +8,6 @@
   <%= render 'shared/errors', { resource: @address } %>
     <%= render 'form', {f: f} %>
     <div class="form-actions">
-    	<% if @address.billing %>
-    		<% f.check_box('billing') %>
-    	<% end %>
-    	<% if @address.default %>
-    		<% f.check_box('default') %>
-    	<% end %>
       <%= link_to "Delete Address", admin_market_address_path(@market, @address), method: :delete, class: "btn pull-left destructive" %>
       <%= f.submit "Update Address" %>
     </div>


### PR DESCRIPTION
This fixes a bug where, when editing a market address, if you had chosen an address to be "default" or "billing" and later returned to edit the address again, the check would not persist to accurately represent the data. I think it should be OK now. Could add more tests for other cases, I think -- does this seem OK?
