### PR TITLE
adding a product unit defaults product code to existing code

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -189,19 +189,19 @@ module Admin
           sibling_unit_id = product.sibling_unit_id[i]
           sibling_unit_description = product.sibling_unit_description[i]
           sibling_product_code = product.sibling_product_code[i]
-          if sibling_id == "0"
-            if sibling_unit_id && sibling_unit_id != ""
+          if sibling_unit_id && sibling_unit_id != ""
+            if sibling_id == "0"
               sibling = product.model.dup
               sibling.unit_id = sibling_unit_id
               sibling.unit_description = sibling_unit_description
               sibling.code = sibling_product_code
               sibling.save
-            end
-          else
-            sibling = Product.find_by(id: sibling_id)
-            if sibling
-              sibling.update(unit_id: sibling_unit_id, unit_description: sibling_unit_description,
-                             code: sibling_product_code)
+            else
+              sibling = Product.find_by(id: sibling_id)
+              if sibling
+                sibling.update(unit_id: sibling_unit_id, unit_description: sibling_unit_description,
+                               code: sibling_product_code)
+              end
             end
           end
         end

--- a/app/views/admin/products/_fields.html.erb
+++ b/app/views/admin/products/_fields.html.erb
@@ -124,7 +124,7 @@
     </td>
     <td class="edit-cell">
       <%= f.text_field :sibling_product_code,
-                       value: "",
+                       value: @product.code || "",
                        multiple: true,
                        class: "column column--full" %>
     </td>


### PR DESCRIPTION
Small improvement to default a newly added unit's product code to the product code of the master product. It might be useful to add product code to the general product, but for most use cases (no product code or all units having the same code) just copying the master product's code works fine.
