### PR TITLE
Fix/payment method dropdown options

### DIFF
--- a/app/assets/javascripts/bank_accounts.js.coffee
+++ b/app/assets/javascripts/bank_accounts.js.coffee
@@ -73,3 +73,6 @@ $ ->
   if accountType = $("#provider_account_type").val()
     if (accountType == 'checking') or (accountType == 'savings')
       showBankAccountControls(accountType)
+
+  $("#provider_account_type").trigger("change");
+  

--- a/app/views/admin/bank_accounts/new.html.erb
+++ b/app/views/admin/bank_accounts/new.html.erb
@@ -60,7 +60,7 @@
       </div>
     </fieldset>
 
-    <fieldset id="credit-card-fields" <%# = raw 'class="is-hidden" disabled' unless @bank_account.account_type.present? && is_credit_card?(@bank_account) %>>
+    <fieldset id="credit-card-fields" <%= raw 'class="is-hidden" disabled' unless @bank_account.account_type.present? && is_credit_card?(@bank_account) %>>
       <div class="row">
         <div class="field column column--half column--guttered">
           <label for="provider_card_number">Card Number</label><br>

--- a/spec/features/organizations/credit_cards/adding_via_stripe_spec.rb
+++ b/spec/features/organizations/credit_cards/adding_via_stripe_spec.rb
@@ -43,7 +43,9 @@ feature "Adding a credit card to an organization", :js, :vcr do
       click_button "Save"
 
       expect(page).not_to have_content("Successfully added a credit card")
-      expect(page).to have_content("Account type: Please select an account type.")
+      
+      # Commented out until we enable Account Types beyond 'Credit Card' 
+      #expect(page).to have_content("Account type: Please select an account type.")
 
       select "Credit Card", from: "provider_account_type"
       fill_in "Card Number", with: "5105105105105"


### PR DESCRIPTION
Weird little fix, this - Rather than kill the dropdown outright (anticipating acceptance of other payment types down the road (per Kate)), I removed the Account Type prompt (effectively setting Credit Card as the default), adjusted the test to not look for the missing (and currently never to be seen) Account Type page text, and triggered the Account Type change event so the page correctly exposes the credit card data fields using the methods already in place.
