### PR TITLE
Fix occurrence of orders appearing where they should not 

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -240,11 +240,21 @@ class Order < ActiveRecord::Base
     end
   end
 
+  # def self.filter_by_user_markets(user, orders)
+  #   result = []
+  #   orders.each do |o|
+  #     if user.markets.include?(o.market)
+  #       result << o
+  #     end
+  #   end
+  #   result
+  # end
+
   def self.orders_for_buyer(user)
     if user.admin?
       all
     else
-      where(buyer_orders_arel(user).or(manager_orders_arel(user))).uniq
+      where(buyer_orders_arel(user).or(manager_orders_arel(user))).uniq.where(market_id: user.markets)
     end
   end
 
@@ -252,7 +262,7 @@ class Order < ActiveRecord::Base
     if user.admin?
       all
     else
-      joins(:products).where(seller_orders_arel(user).or(manager_orders_arel(user))).uniq
+      joins(:products).where(seller_orders_arel(user).or(manager_orders_arel(user))).uniq.where(market_id: user.markets)
     end
   end
 


### PR DESCRIPTION
eg user's former market-belonging affecting their financial reports
(orders for buyers and sellers only show up for markets within current user.markets)
