### PR TITLE
Allow for graceful exit when missing data

### DIFF
--- a/app/views/admin/market_stripe/show.html.erb
+++ b/app/views/admin/market_stripe/show.html.erb
@@ -4,7 +4,7 @@
 
 <div class="row row--partial">
 
-  <% if (@account_info.managed) %>
+  <% if (@account_info.try(:managed)) %>
     <div class="column column--full">
       <br/>
       Stripe is the credit card processing technology that is integrated into the Local Orbit platform and lets you accept credit card payments.<br/><br/>To set up your Stripe account, click the button below and follow the instructions.<br/><br/>Once your account has been created and your information verified, you’ll be able to accept credit card payments on your Local Orbit powered site.<br/><br/>Want to learn more? Check out the <a target="_new" href="https://localorbit.zendesk.com/hc/en-us/articles/217975288
@@ -16,8 +16,8 @@
       <div class="row">
         <div>
           <h1>Account Summary</h1>
-          Available: <strong><%= number_to_currency(@account_balance.available[0].amount/100.0) %></strong>
-          Waiting: <strong><%= number_to_currency(@account_balance.pending[0].amount/100.0) %></strong>
+          Available: <strong><%= number_to_currency(@account_balance.available[0].amount/100.0) if @account_balance.try(:available) %></strong>
+          Waiting: <strong><%= number_to_currency(@account_balance.pending[0].amount/100.0) if @account_balance.try(:pending) %></strong>
         </div>
       </div>
       <br/><br/>
@@ -35,7 +35,7 @@
             </tr>
             </thead>
             <tbody>
-            <% @account_payments.each do |payment| %>
+            <% @account_payments.try(:each) do |payment| %>
               <tr>
                 <td><%= Time.at(payment.created).strftime("%m/%d/%Y %H:%M") %></td>
                 <td><%= payment.type.gsub('_',' ').capitalize %></td>
@@ -58,7 +58,7 @@
             </tr>
             </thead>
             <tbody>
-            <% @account_transfers.each do |transfer| %>
+            <% @account_transfers.try(:each) do |transfer| %>
                 <tr>
                   <td><%= Time.at(transfer.created).strftime("%m/%d/%Y") %></td>
                   <td><%= number_to_currency(transfer.amount/100.0) %></td>


### PR DESCRIPTION
Throwing a 500 error when accessing the Stripe tab on Prod for Chesapeake (and likely any Market without a stripe_account_id).  I'd be inclined to just hide the tab if the Market is missing a stripe_accout_id (as Chesapeake Farm to Table is), but adding the 'try' method on the possibly-nil variables ought to work in the short term