### PR TITLE
Correct quote wrapping when necessary

### DIFF
--- a/vendor/assets/javascripts/fSelect.js
+++ b/vendor/assets/javascripts/fSelect.js
@@ -72,7 +72,11 @@
                     }
                     else {
                         var selected = $el.is('[selected]') ? ' selected' : '';
-                        choices += '<div class="fs-option' + selected + '" data-value="' + $el.prop('value') + '"><span class="fs-checkbox"><i></i></span><div class="fs-option-label">' + $el.html() + '</div></div>';
+                        if($el.prop('value').includes('"')){
+                            choices += '<div class="fs-option' + selected + '" data-value=' + "'" + $el.prop('value') + "'" + '><span class="fs-checkbox"><i></i></span><div class="fs-option-label">' + $el.html() + '</div></div>';
+                        } else {
+                            choices += '<div class="fs-option' + selected + '" data-value="' + $el.prop('value') + '"><span class="fs-checkbox"><i></i></span><div class="fs-option-label">' + $el.html() + '</div></div>';
+                        }
                     }
                 });
 


### PR DESCRIPTION
This fixes a customer reported bug with the product filter - it wasn't working (nor was it 'sticky') for items with doubles quotes in the name (i.e. Tortillas, 6")