### PR TITLE
Feature/add unpay method to order

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -469,7 +469,9 @@ class Order < ActiveRecord::Base
 
   def mark_as_unpaid
     update_attributes(payment_status: 'unpaid', paid_at: nil)
-    items.update_all(payment_status: 'unpaid')
+    items.each do |oi|
+      oi.payment_status = "unpaid"
+    end
     save!
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -338,6 +338,27 @@ describe Order do
     end
   end
 
+  describe "#mark_as_unpaid" do
+    let!(:paid_order) { create(:order, items: items, paid_at: Time.now, payment_status: "paid") }
+    let(:items) { create_list(:order_item, 2, product: create(:product, :sellable), payment_status: "paid") }
+
+    context "with order" do
+      it "marks the order unpaid" do
+        paid_order.mark_as_unpaid
+
+        expect(paid_order.paid_at).to be_nil
+        expect(paid_order.payment_status).to eq("unpaid")
+      end
+
+      it "marks the order items as unpaid" do
+        paid_order.mark_as_unpaid
+
+        expect(paid_order.items[0].payment_status).to eq("unpaid")
+        expect(paid_order.items[1].payment_status).to eq("unpaid")
+      end
+    end
+  end
+
   describe "#sellers" do
     context "no order items" do
       it "returns an empty array" do


### PR DESCRIPTION
Built this out (including the tests) in less time than it took me to go through the manual process (described in the Developers guide) for the fourteen records that needed to be unpaid... I don't think this is a bad thing to include in the platform (from an exposure or risk standpoint), but feel free to discard if you think otherwise...