### PR TITLE
Add config to use mailtrap in dev env, get rid of letter_opener

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,6 @@ end
 
 group :development do
   gem 'bullet'
-  gem 'letter_opener'
   gem 'ultrahook'
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,8 +434,6 @@ GEM
     konacha-chai-matchers (1.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    letter_opener (1.4.1)
-      launchy (~> 2.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -811,7 +809,6 @@ DEPENDENCIES
   konacha
   konacha-chai-matchers
   launchy
-  letter_opener
   mailcatcher
   migration_data
   newrelic-dragonfly

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ See the `docs/` directory for more documentation.
 10. Add `127.0.0.1 localtest.me` to `/etc/hosts`
 11. Go to http://localtest.me:3000 in a browser (we use localtest.me to always point to 127.0.0.1 so we can use subdomains, which localhost doesn't allow.)
 
-See also [stripe howto](docs/stripe_in_development.md) for configuring stripe for development.
+See also:
+  * [stripe howto](docs/stripe_in_development.md) for configuring stripe for development.
+  * Setup a [mailtrap](https://mailtrap.io/) account and put the username and password into your application.yml
 
 ### Production Setup
 

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -36,3 +36,5 @@ QB_ACCESS_TOKEN_SECRET: <QB access token secret>
 QB_REALM_ID: <QB realm id>
 development:
   STRIPE_DEV_MARKET_ACCOUNT_ID: <stripe user id of market that did oauth flow, see docs/stripe.md>
+  MAILTRAP_USERNAME: <MT username>
+  MAILTRAP_PASSWORD: <MT secret>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,7 +16,15 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = {host: "app.#{Figaro.env.domain}", port: 3000}
-  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    user_name:      Figaro.env.mailtrap_username,
+    password:       Figaro.env.mailtrap_password,
+    address:        'smtp.mailtrap.io',
+    domain:         'smtp.mailtrap.io',
+    port:           '2525',
+    authentication: :cram_md5
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/153865488

Use mailtrap instead of letter_opener in dev. Less new tabs getting opened, and better tool all round.