### PR TITLE
Fix for superfluous lot being created when doing a second split on a lot over a year boundary

### DIFF
--- a/app/interactors/update_lots.rb
+++ b/app/interactors/update_lots.rb
@@ -1,7 +1,7 @@
 class UpdateLots
   include Interactor
   def perform
-    return unless order.purchase_order?
+    return unless order.purchase_order? # ie. is a consignment
 
     lot_number = Inventory::Utils.generate_lot_number(order)
 

--- a/lib/inventory/utils.rb
+++ b/lib/inventory/utils.rb
@@ -73,7 +73,7 @@ module Inventory
       end
 
       def upsert_lot(product, lot_number, quantity, split_op = nil)
-        lot = Lot.where("product_id = ? AND number = ? AND EXTRACT(YEAR FROM created_at) = ?", product.id, lot_number, Time.now.year.to_s).first
+        lot = Lot.where("product_id = ? AND number = ?", product.id, lot_number).first
         if lot.present? && !quantity.nil?
           if split_op
             new_qty = lot.quantity + quantity


### PR DESCRIPTION
On GFC's order /admin/orders/89645
We see duplicate transactions and then negative inventory.
This should fix the issue because it will find the existing lot properly now. Before it used to assume the lot's created_at would be within the same year.