### PR TITLE
[LO-797]  hide the × that clears the unit selection

### DIFF
--- a/app/assets/stylesheets/products_chosen_override.scss
+++ b/app/assets/stylesheets/products_chosen_override.scss
@@ -1,4 +1,4 @@
 // hide the × that clears the selection because people think it deletes the unit (mistakenly)
-body.controller-products abbr.search-choice-close {
+body.controller-products.action-show #units_table abbr.search-choice-close {
   display: none;
 }

--- a/app/views/admin/products/_fields.html.erb
+++ b/app/views/admin/products/_fields.html.erb
@@ -221,7 +221,7 @@
 
   <tfoot><tr>
     <td colspan="4">
-      <span class="hint">Not seeing what you need? <%= link_to "Request a New Unit", "#request-new-unit", class: "modal-toggle" %></span>
+      <span class="hint">To remove a unit for this product, please delete it from the <%= link_to 'Products List', admin_products_path %>.</span>
     </td>
   </tr></tfoot>
 </table>


### PR DESCRIPTION
LO-797
On products page hide the × that clears the unit selection because people mistakenly think it deletes the unit