### PR TITLE
Fix CreateManagedStripeAccountForMarket spec

### DIFF
--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -5,6 +5,7 @@ Rails.configuration.stripe = {
 }
 
 Stripe.api_key = Rails.configuration.stripe[:secret_key]
+Stripe.api_version = '2015-04-07'
 
 StripeEvent.configure do |events|
   events.all PaymentProvider::Handlers::AsyncHandler.new


### PR DESCRIPTION
Peg the api version in stripe config so new dev Stripe accounts are using the same API as production.