### PR TITLE
Fix javascript spec helper with updated non-minified es5-shim

### DIFF
--- a/spec/javascripts/spec_helper.js.coffee
+++ b/spec/javascripts/spec_helper.js.coffee
@@ -2,7 +2,7 @@
 #= require jquery
 #= require chai-jquery
 #= require sinon
-#= require es5-shim.min
+#= require es5-shim
 #= require underscore
 
 chai.config.includeStack = true


### PR DESCRIPTION
Fixes an error when running javascript specs with:

    bundle exec rake konacha:run

It now passes again with the new path to the es5-shim dependency included.