### PR TITLE
Use env var of SKYLIGHT_ENABLED=true instead for now

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,7 +53,5 @@ module LocalOrbit
     #   end
     # end
     # config.active_record.raise_in_transactional_callbacks = true
-
-    config.skylight.environments += ['staging']
   end
 end


### PR DESCRIPTION
Use env var of SKYLIGHT_ENABLED=true instead for now to prevent startup error in other envs