### PR TITLE
Add the gem 'active_record_query_trace' and enable it in development.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'underscore-rails'
 gem 'wysihtml5-rails'
 
 gem 'active_model_serializers'
+gem 'active_record_query_trace'
 gem 'active_record_union'
 gem 'acts_as_geocodable'
 gem 'audited-activerecord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       erubis (~> 2.7.0)
     active_model_serializers (0.9.0)
       activemodel (>= 3.2)
+    active_record_query_trace (1.5.4)
     active_record_union (1.0.1)
       activerecord (>= 4.0)
     activemodel (4.1.16)
@@ -791,6 +792,7 @@ PLATFORMS
 DEPENDENCIES
   accountingjs-rails
   active_model_serializers
+  active_record_query_trace
   active_record_union
   activerecord-import
   acts_as_geocodable

--- a/config/initializers/active_record_query_trace.rb
+++ b/config/initializers/active_record_query_trace.rb
@@ -1,0 +1,1 @@
+ActiveRecordQueryTrace.enabled = Rails.env.development?


### PR DESCRIPTION
It will log the source of database queries, super helpful for debugging
and doing performance improvements.

@rbarreca I'm making a separate PR so that I can get this merged down to master quickly as I use it already on several WIP branches.