### PR TITLE
[LO-1105] Fix regression where Mark all delivered button not showing …

### DIFF
--- a/app/policies/order/delivery_status_policy.rb
+++ b/app/policies/order/delivery_status_policy.rb
@@ -8,7 +8,8 @@ class Order::DeliveryStatusPolicy
   def mark_delivered?
     return false if user.buyer_only?
     return false unless order.undelivered_for_user?(user)
-    user.can_manage_market?(order.market) || delivery_schedule_is_direct_to_customer?
+
+    user.can_manage_market?(order.market) || order.market.sellers_edit_orders? || delivery_schedule_is_direct_to_customer?
   end
 
   def mark_undelivered?

--- a/spec/policies/order/delivery_status_policy_spec.rb
+++ b/spec/policies/order/delivery_status_policy_spec.rb
@@ -53,6 +53,12 @@ describe Order::DeliveryStatusPolicy do
           expect(described_class).to_not permit(user, order)
         end
 
+        it 'grants access if suppliers can edit orders and not direct delivery' do
+          allow(market).to receive(:sellers_edit_orders?) { true }
+          allow(order).to receive_message_chain('delivery.delivery_schedule.direct_to_customer?') { false }
+          expect(described_class).to permit(user, order)
+        end
+
         it 'grants access if order is direct delivery' do
           allow(order).to receive_message_chain('delivery.delivery_schedule.direct_to_customer?') { true }
           expect(described_class).to permit(user, order)
@@ -72,7 +78,13 @@ describe Order::DeliveryStatusPolicy do
       let(:user) { buyer }
       let(:undelivered) { true }
 
-      it 'denies access' do
+      it 'denies access by default' do
+        expect(described_class).to_not permit(user, order)
+      end
+
+      it 'denies access even if suppliers can edit orders' do
+        allow(market).to receive(:sellers_edit_orders?) { true }
+        allow(order).to receive_message_chain('delivery.delivery_schedule.direct_to_customer?') { false }
         expect(described_class).to_not permit(user, order)
       end
     end
@@ -103,7 +115,13 @@ describe Order::DeliveryStatusPolicy do
       let(:user) { supplier }
       let(:undelivered) { true }
 
-      it 'denies access' do
+      it 'denies access by default' do
+        expect(described_class).to_not permit(user, order)
+      end
+
+      it 'denies access even if suppliers can edit orders and is direct delivery' do
+        allow(market).to receive(:sellers_edit_orders?) { true }
+        allow(order).to receive_message_chain('delivery.delivery_schedule.direct_to_customer?') { true }
         expect(described_class).to_not permit(user, order)
       end
     end


### PR DESCRIPTION
…even when 'Suppliers can edit orders' was enabled