### PR TITLE
[LO-1138] Update sprockets to 2.12.5, mitigates CVE-2018-3760

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -719,7 +719,7 @@ GEM
     spring (1.1.3)
     spring-commands-rspec (1.0.2)
       spring (>= 0.9.1)
-    sprockets (2.12.4)
+    sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)


### PR DESCRIPTION
[LO-1138] Update sprockets to 2.12.5, mitigates CVE-2018-3760