### PR TITLE
Lo 808 fix email receiver filter

### DIFF
--- a/app/interactors/send_fresh_sheet.rb
+++ b/app/interactors/send_fresh_sheet.rb
@@ -22,14 +22,9 @@ class SendFreshSheet
   end
 
   def send_fresh_sheets_to_subscribed_members
-    unless market.active?
-      context[:notice] = "Provided market (#{market.name}) for fresh sheet distribution is not active."
-      return
-    end
-
     fresh_sheet_type = SubscriptionType.find_by(keyword: SubscriptionType::Keywords::FreshSheet)
     User.
-      where.not(confirmed_at: nil).
+      confirmed.
       in_market(market).
       subscribed_to(fresh_sheet_type).
       uniq.

--- a/app/interactors/send_fresh_sheet.rb
+++ b/app/interactors/send_fresh_sheet.rb
@@ -22,6 +22,11 @@ class SendFreshSheet
   end
 
   def send_fresh_sheets_to_subscribed_members
+    unless market.active?
+      context[:notice] = "Provided market (#{market.name}) for fresh sheet distribution is not active."
+      return
+    end
+
     fresh_sheet_type = SubscriptionType.find_by(keyword: SubscriptionType::Keywords::FreshSheet)
     User.in_market(market).
       subscribed_to(fresh_sheet_type).

--- a/app/interactors/send_fresh_sheet.rb
+++ b/app/interactors/send_fresh_sheet.rb
@@ -28,7 +28,9 @@ class SendFreshSheet
     end
 
     fresh_sheet_type = SubscriptionType.find_by(keyword: SubscriptionType::Keywords::FreshSheet)
-    User.in_market(market).
+    User.
+      where.not(confirmed_at: nil).
+      in_market(market).
       subscribed_to(fresh_sheet_type).
       uniq.
       includes(:subscriptions).

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -5,7 +5,7 @@ class OrderMailer < BaseMailer
     @market = order.market
     @order = BuyerOrder.new(order)
 
-    to_list =  order.organization.users.map { |u| u.enabled_for_organization?(order.organization) && u.is_confirmed? && !u.pretty_email.nil? ? u.pretty_email : nil}
+    to_list =  order.organization.users.map { |u| u.enabled_for_organization?(order.organization) && u.confirmed? && !u.pretty_email.nil? ? u.pretty_email : nil}
     compact_list = to_list.compact
 
     if !compact_list.blank?
@@ -28,7 +28,7 @@ class OrderMailer < BaseMailer
       attachments["packing_list.csv"] = {mime_type: "application/csv", content: csv}
     end
 
-    to_list = seller.users.map { |u| u.enabled_for_organization?(seller) && u.is_confirmed? && !u.pretty_email.nil? ? u.pretty_email : nil}
+    to_list = seller.users.map { |u| u.enabled_for_organization?(seller) && u.confirmed? && !u.pretty_email.nil? ? u.pretty_email : nil}
     compact_list = to_list.compact
 
     if !compact_list.blank?
@@ -60,7 +60,7 @@ class OrderMailer < BaseMailer
 
     attachments["invoice.pdf"] = {mime_type: "application/pdf", content: @order.invoice_pdf.try(:data)}
 
-    to_list = @order.organization.users.map { |u| u.enabled_for_organization?(@order.organization) && u.is_confirmed? ? u.pretty_email : nil}
+    to_list = @order.organization.users.map { |u| u.enabled_for_organization?(@order.organization) && u.confirmed? ? u.pretty_email : nil}
     compact_list = to_list.compact
 
     if !compact_list.blank?
@@ -77,7 +77,7 @@ class OrderMailer < BaseMailer
     @market = order.market
     @order = BuyerOrder.new(order) # Market Managers should see all items
 
-    to_list = order.organization.users.map { |u| u.enabled_for_organization?(order.organization) && u.is_confirmed? ? u.pretty_email : nil}
+    to_list = order.organization.users.map { |u| u.enabled_for_organization?(order.organization) && u.confirmed? ? u.pretty_email : nil}
 
     mail(
       to: to_list,
@@ -92,7 +92,7 @@ class OrderMailer < BaseMailer
     @market = order.market
     @order = BuyerOrder.new(order) # Market Managers should see all items
 
-    to_list = order.organization.users.map { |u| u.enabled_for_organization?(order.organization) && u.is_confirmed? ? u.pretty_email : nil}
+    to_list = order.organization.users.map { |u| u.enabled_for_organization?(order.organization) && u.confirmed? ? u.pretty_email : nil}
 
     mail(
         to: to_list,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -221,7 +221,11 @@ class User < ActiveRecord::Base
   end
 
   def enabled_for_organization?(org)
-    user_organizations.find_by(organization: org).try(:enabled?)
+    user_organizations.where(enabled: true, organization_id: org.id).exists?
+  end
+
+  def enabled_for_market?(market)
+    user_organizations.where(enabled: true, organization_id: market.organization_ids).exists?
   end
 
   def suspended_from_all_orgs?(market)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,6 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable,
          :confirmable, :masqueradable, :omniauthable
 
-  alias_method :is_confirmed?, :confirmed?
-
   trimmed_fields :email
 
   has_and_belongs_to_many :roles, :join_table => :users_roles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,7 @@ class User < ActiveRecord::Base
 
   scope :buyers, -> { joins(:organizations).merge(Organization.buying) }
   scope :sellers, -> { joins(:organizations).merge(Organization.selling) }
-  scope :confirmed, -> {where.not(confirmed_at: nil)}
+  scope :confirmed, -> { where.not(confirmed_at: nil) }
 
   scope :in_market, ->(market) {
     market_id = case market

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,8 +71,8 @@ class User < ActiveRecord::Base
                   market.to_i
                 end
     joins(organizations: :market_organizations).
-    where(market_organizations: {market_id: market_id}).
-    merge(MarketOrganization.visible)
+      where(market_organizations: {market_id: market_id}).
+      merge(MarketOrganization.visible)
   }
 
   # TODO: this needs a spec if we're to bring it in:

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -36,7 +36,7 @@
               <% if user.is_invited? %>
                   <%= link_to "Re-Invite", admin_user_invite_path(user), class: "btn btn--small btn--save" %>
               <% end %>
-              <% if !user.is_confirmed? && current_user.admin? %>
+              <% if !user.confirmed? && current_user.admin? %>
                 <%= link_to "Confirm", admin_user_confirm_path(user), class: "btn btn--small btn--save" %>
               <% end %>
             </td>

--- a/spec/interactors/send_fresh_sheet_spec.rb
+++ b/spec/interactors/send_fresh_sheet_spec.rb
@@ -64,6 +64,14 @@ describe SendFreshSheet do
         expect(context.notice).to eq("Successfully sent the Fresh Sheet")
       end
 
+      it "should not send to unconfirmed users" do
+        subscribed_buyer.update_column(:confirmed_at, nil)
+        SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
+        mails = ActionMailer::Base.deliveries
+        emails = mails.map(&:to).map do |recips| recips.first end
+        expect(emails).not_to include(subscribed_buyer.email)
+      end
+
       it "should not send to inactive markets" do
         market.update_column(:active, false)
         SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)

--- a/spec/interactors/send_fresh_sheet_spec.rb
+++ b/spec/interactors/send_fresh_sheet_spec.rb
@@ -64,10 +64,8 @@ describe SendFreshSheet do
         expect(context.notice).to eq("Successfully sent the Fresh Sheet")
       end
 
-      #TODO - this might not be correct - what does 'active' mean for markets?
-      xit "should not send to inactive markets" do
+      it "should not send to inactive markets" do
         market.update_column(:active, false)
-
         SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
         expect(ActionMailer::Base.deliveries.size).to equal(0)
       end

--- a/spec/interactors/send_fresh_sheet_spec.rb
+++ b/spec/interactors/send_fresh_sheet_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 describe SendFreshSheet do
-  
+
   let!(:market) { create(:market, name: "Mad Dog Farm n Fry", delivery_schedules: [create(:delivery_schedule)]) }
-  let(:note) { "B flat" }
+  let(:note) { "B flat" } #lol
 
   it "sends test emails" do
     context = SendFreshSheet.perform(
@@ -20,42 +20,95 @@ describe SendFreshSheet do
     assert_fresh_sheet_sent_to mail, market, "hossnfeffer@example.com", note
   end
 
-  it "sends Fresh Sheet emails to all users in the given market who subscribe to Fresh Sheets" do
-    fresh = create(:subscription_type, 
-                   keyword: SubscriptionType::Keywords::FreshSheet, 
-                   name: "Test Fresh!")
+  context "sending to subscribers" do
+    let(:fresh_subscription) { create(:subscription_type, keyword: SubscriptionType::Keywords::FreshSheet, name: "Test Fresh!") }
 
-    user1 = create(:user, :buyer)
-    user2 = create(:user, :supplier)
-    user3 = create(:user, :buyer)
-    user4 = create(:user, :buyer)
-    [user1,user2,user3,user4].each do |u|
-      u.subscribe_to(fresh)
+    let(:subscribed_buyer) do
+      user = create(:user, :buyer)
+      create(:organization, :buyer, users:[user], markets:[market])
+      user.subscribe_to(fresh_subscription)
+      user
     end
-    user3.unsubscribe_from(fresh)
 
-    create(:organization, :buyer, users:[user1], markets:[market])
-    create(:organization, :seller, users:[user2], markets:[market])
-    create(:organization, :buyer, users:[user3], markets:[market])
-    create(:organization, :buyer, users:[user4], markets:[create(:market)])
+    let(:subscribed_supplier) do
+      user = create(:user, :supplier)
+      create(:organization, :seller, users:[user], markets:[market])
+      user.subscribe_to(fresh_subscription)
+      user
+    end
 
-    # At this point, user1 and user2 are in our target Market and are subscribed.
-    # user3 is in the Market but not subscribed.
-    # user4 is subscribed, but in a different market
+    let(:unsubscribed_buyer) do
+      user = create(:user, :buyer)
+      create(:organization, :buyer, users:[user], markets:[market])
+      user.subscribe_to(fresh_subscription)
+      user.unsubscribe_from(fresh_subscription)
+      user
+    end
 
-    context = SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
-    expect(context.success?).to eq(true)
-    expect(context.notice).to eq("Successfully sent the Fresh Sheet")
+    let(:subscriber_in_other_market) do
+      user = create(:user, :buyer)
+      create(:organization, :buyer, users:[user], markets:[create(:market)])
+      user.subscribe_to(fresh_subscription)
+      user
+    end
 
-    mails = ActionMailer::Base.deliveries
-    emails = mails.map(&:to).map do |recips| recips.first end
-    expect(emails).to contain_exactly(user1.email, user2.email)
+    context "sends Fresh Sheet emails to all users in the given market who subscribe to Fresh Sheets" do
+      before :each do
+        subscribed_buyer
+        subscribed_supplier
+      end
 
-    mail1 = mails.select do |m| m.to.first == user1.email end.first
-    assert_fresh_sheet_sent_to mail1, market, user1.email, note
+      it "should set success in the context" do
+        context = SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
+        expect(context.success?).to eq(true)
+        expect(context.notice).to eq("Successfully sent the Fresh Sheet")
+      end
 
-    mail2 = mails.select do |m| m.to.first == user2.email end.first
-    assert_fresh_sheet_sent_to mail2, market, user2.email, note
+      #TODO - this might not be correct - what does 'active' mean for markets?
+      xit "should not send to inactive markets" do
+        market.update_column(:active, false)
+
+        SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
+        expect(ActionMailer::Base.deliveries.size).to equal(0)
+      end
+
+      it "should not send to markets users deactivated from organization" do
+        subscribed_buyer.user_organizations.first.update_column(:enabled, false)
+
+        SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
+        mails = ActionMailer::Base.deliveries
+        emails = mails.map(&:to).map do |recips| recips.first end
+        expect(emails).not_to include(subscribed_buyer.email)
+      end
+
+      it "should not send to subscribed users from another market" do
+        subscriber_in_other_market
+
+        SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
+        mails = ActionMailer::Base.deliveries
+        emails = mails.map(&:to).map do |recips| recips.first end
+        expect(emails).to_not contain_exactly(subscriber_in_other_market.email)
+      end
+
+      it "should not send to unsubscribed users" do
+        unsubscribed_buyer
+
+        SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
+        mails = ActionMailer::Base.deliveries
+        emails = mails.map(&:to).map do |recips| recips.first end
+        expect(emails).to_not contain_exactly(unsubscribed_buyer.email)
+      end
+
+      it "should have valid data in the emails" do
+        SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
+        mails = ActionMailer::Base.deliveries
+        mail1 = mails.select do |m| m.to.first == subscribed_buyer.email end.first
+        assert_fresh_sheet_sent_to mail1, market, subscribed_buyer.email, note
+
+        mail2 = mails.select do |m| m.to.first == subscribed_supplier.email end.first
+        assert_fresh_sheet_sent_to mail2, market, subscribed_supplier.email, note
+      end
+    end
   end
 
   it "fails on bad commit value" do
@@ -67,7 +120,7 @@ describe SendFreshSheet do
   #
   # HELPERS
   #
-  
+
   def assert_fresh_sheet_sent_to(mail,market,sent_to,note)
     expect(mail).to be
     expect(mail.to.first).to eq(sent_to)

--- a/spec/interactors/send_fresh_sheet_spec.rb
+++ b/spec/interactors/send_fresh_sheet_spec.rb
@@ -37,20 +37,6 @@ describe SendFreshSheet do
       user
     end
 
-    let(:unsubscribed_buyer) do
-      user = create(:user, :buyer)
-      create(:organization, :buyer, users:[user], markets:[market])
-      user.subscribe_to(fresh_subscription)
-      user.unsubscribe_from(fresh_subscription)
-      user
-    end
-
-    let(:subscriber_in_other_market) do
-      user = create(:user, :buyer)
-      create(:organization, :buyer, users:[user], markets:[create(:market)])
-      user.subscribe_to(fresh_subscription)
-      user
-    end
 
     context "sends Fresh Sheet emails to all users in the given market who subscribe to Fresh Sheets" do
       before :each do
@@ -99,8 +85,11 @@ describe SendFreshSheet do
       end
 
       context "there exists users in other markets" do
-        before :each do
-          subscriber_in_other_market
+        let!(:subscriber_in_other_market) do
+          user = create(:user, :buyer)
+          create(:organization, :buyer, users:[user], markets:[create(:market)])
+          user.subscribe_to(fresh_subscription)
+          user
         end
         it "should not send to users only subscribed to other markets" do
           SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
@@ -111,8 +100,12 @@ describe SendFreshSheet do
       end
 
       context "there are unsubscribed users in the market" do
-        before :each do
-          unsubscribed_buyer
+        let!(:unsubscribed_buyer) do
+          user = create(:user, :buyer)
+          create(:organization, :buyer, users:[user], markets:[market])
+          user.subscribe_to(fresh_subscription)
+          user.unsubscribe_from(fresh_subscription)
+          user
         end
         it "should not send to unsubscribed users" do
           SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)

--- a/spec/interactors/send_fresh_sheet_spec.rb
+++ b/spec/interactors/send_fresh_sheet_spec.rb
@@ -72,12 +72,6 @@ describe SendFreshSheet do
         expect(emails).not_to include(subscribed_buyer.email)
       end
 
-      it "should not send to inactive markets" do
-        market.update_column(:active, false)
-        SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
-        expect(ActionMailer::Base.deliveries.size).to equal(0)
-      end
-
       it "should not send to markets users deactivated from organization" do
         UserOrganization.where(user_id: subscribed_buyer.id).update_all(enabled: false)
 

--- a/spec/interactors/send_fresh_sheet_spec.rb
+++ b/spec/interactors/send_fresh_sheet_spec.rb
@@ -71,7 +71,7 @@ describe SendFreshSheet do
       end
 
       it "should not send to markets users deactivated from organization" do
-        subscribed_buyer.user_organizations.first.update_column(:enabled, false)
+        UserOrganization.where(user_id: subscribed_buyer.id).update_all(enabled: false)
 
         SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
         mails = ActionMailer::Base.deliveries


### PR DESCRIPTION
explorations and (expected) fix for https://localorbit.atlassian.net/browse/LO-808
I'm not entirely sure of all the vectors by which a user can be valid/enabled or not, I've added specs to cover all the fresh sheet sending situations I found including one that fails when run against `master` but passes with the included fix.

On master:
```
SendFreshSheet
  fails on bad commit value
  sends test emails
  sending to subscribers
    sends Fresh Sheet emails to all users in the given market who subscribe to Fresh Sheets
      should not send to unsubscribed users
      should not send to markets users deactivated from organization
      should set success in the context
      should not send to inactive markets (FAILED - 1)
      should have valid data in the emails
      should not send to subscribed users from another market
```

but this branch passes all specs.