### PR TITLE
minor refactoring to order_mailer

### DIFF
--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -1,14 +1,13 @@
 class OrderMailer < BaseMailer
   def buyer_confirmation(order)
-    return if order.market.is_consignment_market?
-
     @market = order.market
+    return if @market.is_consignment_market?
+
     @order = BuyerOrder.new(order)
 
-    to_list =  order.organization.users.map { |u| u.enabled_for_organization?(order.organization) && u.confirmed? && !u.pretty_email.nil? ? u.pretty_email : nil}
-    compact_list = to_list.compact
+    to_list = recipient_list(order)
 
-    if !compact_list.blank?
+    if !to_list.blank?
       mail(
         to: to_list,
         subject: "Thank you for your order"
@@ -17,27 +16,30 @@ class OrderMailer < BaseMailer
   end
 
   def seller_confirmation(order, seller)
-    return if order.market.is_consignment_market?
-
     @market = order.market
+    return if @market.is_consignment_market?
+
     @order = SellerOrder.new(order, seller) # Selling users organizations only see
     @seller = seller
 
-    to_list = seller.users.map { |u| u.enabled_for_organization?(seller) && u.confirmed? && !u.pretty_email.nil? ? u.pretty_email : nil}
-    compact_list = to_list.compact
+    to_list = seller.
+                users.
+                confirmed.
+                map { |u| u.enabled_for_organization?(seller) && !u.pretty_email.nil? ? u.pretty_email : nil}.
+                compact
 
-    if !compact_list.blank?
+    if !to_list.blank?
       mail(
-        to: compact_list,
+        to: to_list,
         subject: "New order on #{@market.name}"
       )
     end
   end
 
   def market_manager_confirmation(order)
-    return if order.market.is_consignment_market?
-
     @market = order.market
+    return if @market.is_consignment_market?
+
     @order = BuyerOrder.new(order) # Market Managers should see all items
 
     mail(
@@ -49,16 +51,13 @@ class OrderMailer < BaseMailer
   def invoice(order_id)
 
     @order  = BuyerOrder.new(Order.find(order_id))
-    return if @order.market.is_consignment_market?
-
     @market = @order.market
+    return if @market.is_consignment_market?
 
     attachments["invoice.pdf"] = {mime_type: "application/pdf", content: @order.invoice_pdf.try(:data)}
 
-    to_list = @order.organization.users.map { |u| u.enabled_for_organization?(@order.organization) && u.confirmed? ? u.pretty_email : nil}
-    compact_list = to_list.compact
-
-    if !compact_list.blank?
+    to_list = recipient_list(order)
+    if !to_list.blank?
       mail(
         to: to_list,
         subject: "New Invoice"
@@ -67,30 +66,26 @@ class OrderMailer < BaseMailer
   end
 
   def buyer_order_updated(order)
-    return if order.market.is_consignment_market?
-
     @market = order.market
+    return if @market.is_consignment_market?
+
     @order = BuyerOrder.new(order) # Market Managers should see all items
 
-    to_list = order.organization.users.map { |u| u.enabled_for_organization?(order.organization) && u.confirmed? ? u.pretty_email : nil}
-
     mail(
-      to: to_list,
+      to: recipient_list(order),
       subject: "#{@market.name}: Order #{order.order_number} Updated",
       template_name: "order_updated"
     )
   end
 
   def buyer_order_removed(order)
-    return if order.market.is_consignment_market?
-
     @market = order.market
+    return if @market.is_consignment_market?
+
     @order = BuyerOrder.new(order) # Market Managers should see all items
 
-    to_list = order.organization.users.map { |u| u.enabled_for_organization?(order.organization) && u.confirmed? ? u.pretty_email : nil}
-
     mail(
-        to: to_list,
+        to: recipient_list(order),
         subject: "#{@market.name}: Order #{order.order_number} Updated - Item Removed",
         template_name: "order_updated"
     )
@@ -103,7 +98,10 @@ class OrderMailer < BaseMailer
     @order = SellerOrder.new(order, seller) # Selling users organizations only see
     @seller = seller
 
-    to_list = seller.users.map { |u| u.enabled_for_organization?(seller) ? u.pretty_email : nil}
+    to_list = seller.
+                users.
+                map { |u| u.enabled_for_organization?(seller) ? u.pretty_email : nil}.
+                compact
 
     mail(
       to: to_list,
@@ -144,4 +142,14 @@ class OrderMailer < BaseMailer
     )
   end
 
+  private
+
+  def recipient_list(order)
+    order.
+      organization.
+      users.
+      confirmed.
+      map { |u| u.enabled_for_organization?(order.organization) ? u.pretty_email : nil}.
+      compact
+  end
 end


### PR DESCRIPTION
Wasn't sure if this was in scope for the 'confirmed?' refactoring (suggested by Rob) but afterwards Weston said it was worth doing while it was still fresh.

This extracts common behaviour of getting email addresses from an order, and provides a few minor code cleanups & performance optimizations. 

edit: `rspec spec/mailers/order_mailer_spec.rb` runs green 