### PR TITLE
Disable show_previews

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -94,8 +94,9 @@ Rails.application.configure do
   }
 
   # Enable mailer previews on staging
-  config.action_mailer.show_previews = true
-  config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
+  # TODO: uncomment this when we get to rails 4.2+
+  # config.action_mailer.show_previews = true
+  # config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
 
   config.react.variant = :production
 end


### PR DESCRIPTION
Unfortunately we can't have mailer previews outside of development until Rails 4.2.1+