### PR TITLE
Add more org info in 'New organization registration' email to fix #3299

### DIFF
--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -4,8 +4,8 @@ class OrganizationDecorator < Draper::Decorator
 
   delegate_all
 
-  def org_type_string
-    organization.supplier? ? 'supplier' : 'buyer'
+  def human_org_type
+    h.t(org_type, scope: [:decorators, :organization, :org_type])
   end
 
   def locations_map(w=340, h=300)

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -4,6 +4,10 @@ class OrganizationDecorator < Draper::Decorator
 
   delegate_all
 
+  def org_type_string
+    organization.supplier? ? 'supplier' : 'buyer'
+  end
+
   def locations_map(w=340, h=300)
     addresses = locations.visible.map do |location|
       location.geocode if location

--- a/app/mailers/market_mailer.rb
+++ b/app/mailers/market_mailer.rb
@@ -41,13 +41,13 @@ class MarketMailer < BaseMailer
 
   def registration(market, organization)
     @market = market
-    @organization = organization
+    @organization = organization.decorate
     recipients = market.managers.map(&:pretty_email)
 
     if recipients.any?
       mail(
         to: recipients,
-        subject: "New organization registration"
+        subject: "New #{@organization.org_type_string} registration"
       )
     end
   end

--- a/app/mailers/market_mailer.rb
+++ b/app/mailers/market_mailer.rb
@@ -47,7 +47,7 @@ class MarketMailer < BaseMailer
     if recipients.any?
       mail(
         to: recipients,
-        subject: "New #{@organization.org_type_string} registration"
+        subject: "New #{@organization.human_org_type} registration"
       )
     end
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -116,6 +116,14 @@ class Organization < ActiveRecord::Base
     can_sell? && markets.joins(:organization => [:plan]).where(allow_cross_sell: true, plans: {cross_selling: true}).any?
   end
 
+  def buyer?
+    org_type == 'B'
+  end
+
+  def supplier?
+    org_type == 'S'
+  end
+
   def update_product_delivery_schedules
     reload.products.each(&:save) if persisted?
   end

--- a/app/views/market_mailer/registration.html.erb
+++ b/app/views/market_mailer/registration.html.erb
@@ -1,5 +1,5 @@
 <h1>You’re growing!</h1>
-<p>A new <%= @organization.org_type_string %> has registered for your market!</p>
+<p>A new <%= @organization.human_org_type %> has registered for your market!</p>
 
 <dl>
   <dt>Company:</dt>

--- a/app/views/market_mailer/registration.html.erb
+++ b/app/views/market_mailer/registration.html.erb
@@ -1,5 +1,5 @@
 <h1>You’re growing!</h1>
-<p>A new organization has registered for your market!</p>
+<p>A new <%= @organization.org_type_string %> has registered for your market!</p>
 
 <dl>
   <dt>Company:</dt>
@@ -13,8 +13,29 @@
   <dt>Email:</dt>
   <dd><%= @organization.users.first.email %></dd>
 </dl>
+<% unless @organization.locations.empty? %>
+<dl>
+  <dt>Phone:</dt>
+  <dd><%= @organization.locations.first.phone %></dd>
+</dl>
+<dl>
+  <dt>Address:</dt>
+  <dd>
+    <%= @organization.locations.first.name %><br />
+    <%= @organization.locations.first.address %><br />
+    <%= @organization.locations.first.city %>, <%= @organization.locations.first.state %> <%= @organization.locations.first.zip %>
+  </dd>
+</dl>
+<% end %>
+<% if @organization.buyer? %>
+<dl>
+  <dt>Buyer Type:</dt>
+  <dd><%= @organization.buyer_org_type %></dd>
+</dl>
+<% end %>
 
 <% unless @organization.active? %>
+<br />
 <div class="lo_call_to_action">
 
   <p>

--- a/config/locales/decorators/organization.yml
+++ b/config/locales/decorators/organization.yml
@@ -1,0 +1,8 @@
+en:
+  decorators:
+    organization:
+       org_type:
+         S: supplier
+         B: buyer
+         M: market
+         A: admin

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe OrganizationDecorator do
+  let(:supplier_org) { build(:organization, :seller, :decorated) }
+  let(:buyer_org)    { build(:organization, :buyer, :decorated) }
+  let(:market_org)   { build(:organization, :market, :decorated) }
+  let(:admin_org)    { build(:organization, :admin, :decorated) }
+
+  describe '#human_org_type' do
+    it 'is valid' do
+      expect(supplier_org.human_org_type).to eq('supplier')
+      expect(buyer_org.human_org_type).to eq('buyer')
+      expect(market_org.human_org_type).to eq('market')
+      expect(admin_org.human_org_type).to eq('admin')
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -435,6 +435,12 @@ FactoryBot.define do
         create(:location, organization: org)
       end
     end
+
+    trait :decorated do
+      initialize_with do
+        OrganizationDecorator.new(new)
+      end
+    end
   end
 
   factory :payment do

--- a/spec/mailers/market_mailer_spec.rb
+++ b/spec/mailers/market_mailer_spec.rb
@@ -17,6 +17,7 @@ describe MarketMailer do
     include_context "fresh sheet and newsletter subscription types"
 
     let!(:token) {"xyz--unsubscribe-me-987"}
+
     it "only shows products for the given market" do
       user = create(:user)
       fresh_sheet = MarketMailer.fresh_sheet(market: market_in, to: user.pretty_email, unsubscribe_token: token)
@@ -38,6 +39,67 @@ describe MarketMailer do
       expect(fresh_sheet.body).to include("Rockin")
       expect(fresh_sheet.body).not_to include("Click here to")
       expect(fresh_sheet.body).not_to include(%|href="#{unsubscribe_subscriptions_url(token:token)}"|)
+    end
+  end
+
+  describe 'registration' do
+    let(:market)   { create(:market, organizations: [organization]) }
+    let!(:manager) { create(:user, :market_manager, managed_markets: [market]) }
+    let(:mailer)   { MarketMailer.registration(market, organization) }
+
+    context 'new supplier mail' do
+      let(:organization) { create(:organization, :seller, :single_location, active: false) }
+      let!(:user)        { create(:user, :supplier, organizations: [organization]) }
+
+      it 'is sent to market manager' do
+        expect(mailer).to deliver_to([manager.email])
+      end
+
+      it 'has correct role in subject' do
+        expect(mailer.subject).to eq('New supplier registration')
+      end
+
+      it 'includes company name' do
+        expect(mailer.body).to have_content("Company: #{organization.name}")
+      end
+
+      it 'does not include buyer type' do
+        expect(mailer.body).to_not have_content('Buyer Type:')
+      end
+
+      it 'includes user name' do
+        expect(mailer.body).to have_content("Name: #{user.name}")
+      end
+
+      it 'includes user email' do
+        expect(mailer.body).to have_content("Email: #{user.email}")
+      end
+
+      it 'includes organization phone' do
+        expect(mailer.body).to have_content("Phone: #{organization.locations.first.phone}")
+      end
+
+      it 'includes organization address' do
+        l = organization.locations.first
+        expect(mailer.body).to have_content("Address: #{l.name} #{l.address} #{l.city}, #{l.state} #{l.zip}")
+      end
+
+      it 'includes Edit Organization button' do
+        expect(mailer.body).to have_link('Edit Organization', href: admin_organization_url(organization, host: market.domain))
+      end
+    end
+
+    context 'new buyer mail' do
+      let(:organization) { create(:organization, :buyer, :single_location, active: false) }
+      let!(:user)        { create(:user, :buyer, organizations: [organization]) }
+
+      it 'has correct role in subject' do
+        expect(mailer.subject).to eq('New buyer registration')
+      end
+
+      it 'includes buyer type' do
+        expect(mailer.body).to have_content("Buyer Type: #{organization.buyer_org_type}")
+      end
     end
   end
 end


### PR DESCRIPTION
Small fix I wanted to get out. Marginally improve info in new org registration email to market manager. For issue #3299. 