### PR TITLE
Show correct branding and confirm link when a user registers

### DIFF
--- a/app/interactors/send_email_confirmation_request.rb
+++ b/app/interactors/send_email_confirmation_request.rb
@@ -2,6 +2,10 @@ class SendEmailConfirmationRequest
   include Interactor
 
   def perform
+    dead_code!
+
+    require_in_context :user
+
     user.send_confirmation_instructions if user
   end
 end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -55,15 +55,25 @@ class Registration
 
       organization.markets << market
       organization.locations.build(location_params)
-      organization.save!(validate:false)
+      organization.save!(validate: false)
 
-      # create the user second so we have the organization available
-      # to the confirmation email
       self.user = User.find_by(email: email) || User.new(user_params)
+
+      # Skip automatic confirmation email so we can be sure UserOrganization
+      # associations are saved completely before sending email.
+      user.skip_confirmation_notification!
+
       user.organizations << organization
-      user.attempt_set_password(user_params)
-      user.invitation_token=nil
-      user.save!
+      user.password = user_params[:password]
+      user.password_confirmation = user_params[:password_confirmation]
+      user.invitation_token = nil
+      success = user.save!
+
+      # Ensure Org, User, and UserOrg relation are saved before sending email
+      # so we can display proper content.
+      user.send_confirmation_instructions
+
+      success
     else
       false
     end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,3 @@
-<%# gets the market for the email layout. Isn't ideal, but works well. %>
-
 <% if @market = @resource.default_market
      market_name = @market.name
    else

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -2,8 +2,6 @@ require "spec_helper"
 
 describe "Register" do
   context "a new organization for a market" do
-    #let!(:manager) { create(:user, :market_manager) }
-
     context "automatically activated" do
       let!(:market) { create(:market, auto_activate_organizations: true) }
 
@@ -37,8 +35,6 @@ describe "Register" do
           click_button "Sign Up"
         end
 
-
-
         it "creates a new organization" do
           expect(page).to have_content("Registration: Step Two")
           expect(page).to have_content("daniel@collectiveidea.com")
@@ -50,15 +46,14 @@ describe "Register" do
           expect(Organization.last.markets).not_to be_empty
         end
 
-        it "sends a confirmation email" do
-          open_email("daniel@collectiveidea.com")
-          expect(current_email.body).to have_content("Verify Email Address")
-        end
+        it 'sends a confirmation email' do
+          user = User.find_by(email: 'daniel@collectiveidea.com')
 
-        # it 'sends the market managers a notification' do
-        #   open_email(manager.email)
-        #   expect(current_email.body).to have_content("A new organization has registered for your market!")
-        # end
+          open_email('daniel@collectiveidea.com')
+          expect(current_email.body).to have_link('Verify Email Address',
+            href: user_confirmation_url(confirmation_token: user.confirmation_token,
+                                        host: market.domain))
+        end
       end
 
       context "happy path with an existing email" do
@@ -127,8 +122,8 @@ describe "Register" do
 
           expect(page).to have_content("Registration: Step One")
 
-          select "British Columbia", from: "State" 
-          select "Quebec", from: "State" 
+          select "British Columbia", from: "State"
+          select "Quebec", from: "State"
           select "Ontario", from: "State"
         end
       end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-# TODO: THIS CLASS NEEDS MORE UNIT TESTS! 
+# TODO: THIS CLASS NEEDS MORE UNIT TESTS!
 describe Registration do
   let(:market) { create(:market) }
 
@@ -23,24 +23,42 @@ describe Registration do
     Registration.new(registration_attrs)
   }
 
-  describe "address_label" do
-    it "saves Location name based on address_label" do
-      label = "The Address Label"
-      registration_attrs[:address_label] = label
+  describe '#save' do
+    describe "address_label" do
+      it "saves Location name based on address_label" do
+        label = "The Address Label"
+        registration_attrs[:address_label] = label
 
-      success = registration.save
-      expect(success).to be true
+        success = registration.save
+        expect(success).to be true
 
-      expect(registration.organization.locations.first.name).to eq(label)
+        expect(registration.organization.locations.first.name).to eq(label)
+      end
+
+      it "defaults to 'Default Address' when saving a new Location" do
+        registration_attrs[:address_label] = nil
+
+        success = registration.save
+        expect(success).to be true
+
+        expect(registration.organization.locations.first.name).to eq("Default Address")
+      end
     end
 
-    it "defaults to 'Default Address' when saving a new Location" do
-      registration_attrs[:address_label] = nil
+    describe 'user' do
+      it 'belongs to proper organization' do
+        success = registration.save
+        expect(success).to be true
 
-      success = registration.save
-      expect(success).to be true
+        expect(registration.user.organizations).to include(registration.organization)
+      end
 
-      expect(registration.organization.locations.first.name).to eq("Default Address")
+      it 'password is valid' do
+        success = registration.save
+        expect(success).to be true
+
+        expect(registration.user.valid_password?('password1')).to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes 3339.

- Ensure email goes out after user is saved so the UserOrg association is saved before trying to brand confirmation_instructions email.
- Improve logic in user.default_market so it will prefer active Orgs but for Orgs that are yet to be activated, it will still return the most likely default market.