### PR TITLE
3338 newsletter target fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -419,7 +419,7 @@ GEM
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflecto (0.0.2)
-    interactor (2.1.0)
+    interactor (2.1.1)
     interactor-rails (1.0.1)
       interactor (< 3)
       rails (>= 3, < 5)

--- a/app/controllers/admin/fees_controller.rb
+++ b/app/controllers/admin/fees_controller.rb
@@ -15,14 +15,14 @@ module Admin
 
       if @market.update_attributes(market_attrs) && @organization.update_attributes(org_attrs)
 
-        if @market.organization.plan.solo_supplier? && @market.organizations.where(org_type: "S").count == 0
+        if @market.organization.plan.solo_supplier? && @market.organizations.where(org_type: Organization::TYPE_SUPPLIER).count == 0
           organization_params = {
-              :name => @market.name,
-              :can_sell => true,
-              :org_type => 'S',
-              :active => true,
-              :allow_credit_cards => @market.allow_credit_cards,
-              :allow_purchase_orders => @market.allow_purchase_orders
+              name: @market.name,
+              can_sell: true,
+              org_type: Organization::TYPE_SUPPLIER,
+              active: true,
+              allow_credit_cards: @market.allow_credit_cards,
+              allow_purchase_orders: @market.allow_purchase_orders
           }
           result = CreateOrganization.perform(organization_params: organization_params, user: current_user, market_id: @market.id)
           puts 'Solo Org Result: ' + result.to_s

--- a/app/controllers/admin/market_qb_profile_controller.rb
+++ b/app/controllers/admin/market_qb_profile_controller.rb
@@ -74,7 +74,10 @@ class Admin::MarketQbProfileController < AdminController
     # TODO: Disable button during use, add status indicator? Separate buttons for each?
 
     @qb_profile = @market.organization.qb_profile
-    customers = current_user.managed_organizations.where(org_type: 'B').where(qb_org_id: nil)
+    customers = current_user.
+                  managed_organizations.
+                  where(org_type: Organization::TYPE_BUYER,
+                        qb_org_id: nil)
     puts customers.length
     customers.each do |cust|
       retry_cnt = 0
@@ -93,7 +96,10 @@ class Admin::MarketQbProfileController < AdminController
         end
       end
 
-    vendors = current_user.managed_organizations.where(org_type: 'S').where(qb_org_id: nil)
+    vendors = current_user.
+                managed_organizations.
+                where(org_type: Organization::TYPE_SUPPLIER,
+                      qb_org_id: nil)
     puts customers.length
     vendors.each do |vend|
       retry_cnt = 0

--- a/app/controllers/admin/order_items_controller.rb
+++ b/app/controllers/admin/order_items_controller.rb
@@ -76,7 +76,7 @@ module Admin
         joins(:order).
         includes(order: :organization, product: :organization).
         preload(product: [:organization, :category], order: [:market, :organization]).
-        where('orders.order_type = \'sales\'')
+        where("orders.order_type = 'sales'")
     end
 
     def prepare_filter_data(order_items)

--- a/app/controllers/admin/order_items_controller.rb
+++ b/app/controllers/admin/order_items_controller.rb
@@ -6,7 +6,7 @@ module Admin
     before_action :find_sticky_params, only: :index
 
     def index
-      if params["clear"]
+      if params['clear']
         redirect_to url_for(params.except(:clear))
       else
         items = fetch_order_items
@@ -22,7 +22,7 @@ module Admin
           format.html { @order_items = @q.result.page(params[:page]).per(@query_params[:per_page]) }
           format.csv do
             Delayed::Job.enqueue ::CSVExport::CSVSoldItemsExportJob.new(current_user, @q.result.map(&:id))
-            flash[:notice] = "Please check your email for export results."
+            flash[:notice] = 'Please check your email for export results.'
             redirect_to admin_order_items_path
           end
         end
@@ -67,7 +67,7 @@ module Admin
 
     def perform_search_and_calculate_totals(items, search)
       query = items.includes(:product, :order).search(search)
-      query.sorts = ["order_placed_at desc", "name"] if query.sorts.empty?
+      query.sorts = ['order_placed_at desc', 'name'] if query.sorts.empty?
       [query, OrderTotals.new(query.result)]
     end
 
@@ -76,7 +76,7 @@ module Admin
         joins(:order).
         includes(order: :organization, product: :organization).
         preload(product: [:organization, :category], order: [:market, :organization]).
-        where("orders.order_type = 'sales'")
+        where('orders.order_type = \'sales\'')
     end
 
     def prepare_filter_data(order_items)
@@ -88,15 +88,21 @@ module Admin
     end
 
     def fetch_markets_list(order_items)
-      @markets = Market.select(:id, :name).where(id: order_items.pluck("orders.market_id")).order(:name).uniq
+      @markets = Market.select(:id, :name).where(id: order_items.pluck('orders.market_id')).order(:name).uniq
     end
 
     def fetch_sellers_list(order_items)
-      @sellers = Organization.select(:id, :name).where(org_type: 'S', id: order_items.joins(:product).pluck("products.organization_id")).order(:name).uniq
+      @sellers = Organization.select(:id, :name).where(
+        org_type: Organization::TYPE_SUPPLIER,
+        id: order_items.joins(:product).pluck('products.organization_id')
+      ).order(:name).uniq
     end
 
     def fetch_buyers_list(order_items)
-      @buyers = Organization.select(:id, :name).where(org_type: 'B', id: order_items.pluck("orders.organization_id")).order(:name).uniq
+      @buyers = Organization.select(:id, :name).where(
+        org_type: Organization::TYPE_BUYER,
+        id: order_items.pluck('orders.organization_id')
+      ).order(:name).uniq
     end
 
     def fetch_delivery_statuses(order_items)

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -7,7 +7,7 @@ module Admin
     before_action :find_sticky_params, only: :index
 
     def index
-      if params["clear"]
+      if params['clear']
         redirect_to url_for(params.except(:clear))
       else
         @organizations = current_user.managed_organizations.periscope(@query_params)
@@ -16,13 +16,13 @@ module Admin
         respond_to do |format|
           format.html { @organizations = @organizations.page(params[:page]).per(@query_params[:per_page]) }
           format.csv  do
-            if ENV["USE_UPLOAD_QUEUE"] == "true"
+            if ENV['USE_UPLOAD_QUEUE'] == 'true'
               orgs = @organizations.map(&:id)
               Delayed::Job.enqueue ::CSVExport::CSVOrganizationExportJob.new(current_user, orgs)
-              flash[:notice] = "Please check your email for export results."
+              flash[:notice] = 'Please check your email for export results.'
               redirect_to admin_organizations_path
             else
-              @filename = "organizations.csv"
+              @filename = 'organizations.csv'
             end
           end
         end
@@ -46,7 +46,7 @@ module Admin
       auto_activate = Market.find(params[:initial_market_id]).try(:auto_activate_organizations) unless params[:initial_market_id].empty?
 
       op = organization_params.merge({:org_type => org_type, :payment_model => current_market.is_consignment_market? ? 'consignment' : 'buysell'})
-      op.merge!({active: "1"}) if (org_type == "B" && auto_activate)
+      op.merge!({active: '1'}) if (org_type == Organization::TYPE_BUYER && auto_activate)
       op.except!(:markets)
 
       result = RegisterStripeOrganization.perform(organization_params: op, user: current_user, market_id: params[:initial_market_id])
@@ -66,7 +66,7 @@ module Admin
     def show
       @markets = current_user.markets.order('name')
       if @organization.blank?
-        redirect_to action: :index, alert: "That organization is no longer available"
+        redirect_to action: :index, alert: 'That organization is no longer available'
       else
         @org_markets = @organization.markets.pluck(:id)
       end
@@ -76,7 +76,7 @@ module Admin
       # This updates the association through market_organizations, adding and deleting rows (rather than setting deleted_at)
       @organization.markets = Market.find(params[:organization][:markets].map(&:to_i)) unless params[:organization][:markets].blank?
 
-      if @organization.can_sell && organization_params[:can_sell]=="0" && (current_user.admin? || current_user.market_manager?)
+      if @organization.can_sell && organization_params[:can_sell]=='0' && (current_user.admin? || current_user.market_manager?)
         disable_supplier_inventory
       end
 
@@ -97,10 +97,10 @@ module Admin
     end
 
     def update_org_type(can_sell)
-      if can_sell == true || can_sell == 'true' || can_sell == "1"
-        "S"
+      if can_sell == true || can_sell == 'true' || can_sell == '1'
+        Organization::TYPE_SUPPLIER
       else
-        "B"
+        Organization::TYPE_BUYER
       end
     end
 
@@ -124,15 +124,15 @@ module Admin
       schedules = find_delivery_schedules
       ids = schedules.values.flatten.map {|schedule| schedule.id.to_s }
 
-      render partial: "delivery_schedules", locals: {delivery_schedules: schedules, selected_ids: ids, product: nil, organization: @organization}
+      render partial: 'delivery_schedules', locals: {delivery_schedules: schedules, selected_ids: ids, product: nil, organization: @organization}
     end
 
     def market_memberships
-      render partial: "market_memberships"
+      render partial: 'market_memberships'
     end
 
     def available_inventory
-      render partial: "available_inventory", locals: { organization: @organization }
+      render partial: 'available_inventory', locals: { organization: @organization }
     end
 
     private

--- a/app/controllers/sessions/organizations_controller.rb
+++ b/app/controllers/sessions/organizations_controller.rb
@@ -3,11 +3,14 @@ module Sessions
     before_action :hide_admin_navigation
 
     def new
-      if current_market.is_consignment_market?
-        @organizations = current_user.managed_organizations_within_market(current_market).active.where(org_type: 'B').order(:name)
-      else
-        @organizations = current_user.managed_organizations_within_market(current_market).active.order(:name)
-      end
+
+      orgs_relation = current_user.managed_organizations_within_market(current_market).active
+      @organizations = if current_market.is_consignment_market?
+                         orgs_relation.where(org_type: Organization::TYPE_BUYER)
+                       else
+                         orgs_relation
+                       end.order(:name)
+
       session.delete(:cart_id)
       session.delete(:current_organization_id)
       session.delete(:current_supplier_id)

--- a/app/interactors/create_supplier_org_for_producer.rb
+++ b/app/interactors/create_supplier_org_for_producer.rb
@@ -5,7 +5,16 @@ class CreateSupplierOrgForProducer
     if !market.organization.plan.nil? && (market.organization.plan.stripe_id == "PRODUCER" || market.organization.plan.stripe_id == "PRODUCER_2017")
       organization_params = context[:organization].as_json
 
-      org = Organization.new(organization_params.slice(:id).merge(name: "#{organization_params['name']} Supplier", active: true, allow_purchase_orders: true, allow_credit_cards: true, can_sell: true, org_type: 'S'))
+      org = Organization.
+              new(organization_params.
+                    slice(:id).
+                    merge(name: "#{organization_params['name']} Supplier",
+                          active: true,
+                          allow_purchase_orders: true,
+                          allow_credit_cards: true,
+                          can_sell: true,
+                          org_type: Organization::TYPE_SUPPLIER)
+                 )
       market.organizations << org
     end
   end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -48,9 +48,9 @@ class Registration
       self.organization = Organization.new(organization_params)
 
       if organization_params[:can_sell]
-        organization.org_type = "S"
+        organization.org_type = 'S'
       else
-        organization.org_type = "B"
+        organization.org_type = 'B'
       end
 
       organization.markets << market
@@ -89,7 +89,8 @@ class Registration
       buyer_org_type: buyer_org_type,
       ownership_type: ownership_type,
       non_profit: non_profit,
-      professional_organizations: professional_organizations
+      professional_organizations: professional_organizations,
+      active: market.auto_activate_organizations
     }
   end
 

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -48,9 +48,9 @@ class Registration
       self.organization = Organization.new(organization_params)
 
       if organization_params[:can_sell]
-        organization.org_type = 'S'
+        organization.org_type = Organization::TYPE_SUPPLIER
       else
-        organization.org_type = 'B'
+        organization.org_type = Organization::TYPE_BUYER
       end
 
       organization.markets << market

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,7 @@ class User < ActiveRecord::Base
                   market.to_i
                 end
     joins(organizations: :market_organizations).
+      merge(Organization.active).
       where(market_organizations: {market_id: market_id}).
       merge(MarketOrganization.visible)
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,7 +228,10 @@ class User < ActiveRecord::Base
   def seller?
     return false if admin? || market_manager?
     return @seller if !@seller.nil?
-    @seller = user_organizations.includes(:organization).where(organizations: {org_type: 'S'}).exists?
+    @seller = user_organizations.
+                includes(:organization).
+                where(organizations: {org_type: Organization::TYPE_SUPPLIER}).
+                exists?
   end
 
   def admin_or_mm?
@@ -238,7 +241,11 @@ class User < ActiveRecord::Base
   def buyer_only?
     return false if admin? || market_manager? || seller?
     return @buyer if !@buyer.nil?
-    @buyer = user_organizations.includes(:organization).where(organizations: {org_type: 'B'}).exists?
+    @buyer = user_organizations.
+               includes(:organization).
+               where(
+                 organizations: {org_type: Organization::TYPE_BUYER}
+               ).exists?
   end
 
   def is_seller_with_purchase?

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -266,11 +266,21 @@ class ReportPresenter
     end
 
     if includes_filter?(:seller_name)
-      @sellers = Organization.select(:id, :name).where(org_type: 'S', id: items.joins(:product).pluck("products.organization_id")).order(:name).uniq
+      @sellers = Organization.
+                   select(:id, :name).
+                   where(org_type: Organization::TYPE_SUPPLIER,
+                         id: items.joins(:product).pluck("products.organization_id")).
+                   order(:name).
+                   uniq
     end
 
     if includes_filter?(:buyer_name)
-      @buyers = Organization.active.select(:id, :name).where(id: items.pluck("orders.organization_id")).order(:name).uniq
+      @buyers = Organization.
+                  active.
+                  select(:id, :name).
+                  where(id: items.pluck("orders.organization_id")).
+                  order(:name).
+                  uniq
     end
 
     if includes_filter?(:category_name)
@@ -335,7 +345,7 @@ class ReportPresenter
 
     # Below: additions for lot reporting
     if includes_field?(:lot_info)
-      items = items.includes(:lots) 
+      items = items.includes(:lots)
     end
 
     ## TODO: Possible this information can be drawn from the lot, in-view, if all lots for a given OrderItem are known ^

--- a/app/views/admin/organizations/_form.html.erb
+++ b/app/views/admin/organizations/_form.html.erb
@@ -164,7 +164,7 @@
     </fieldset>
   <% end %>
 
-  <% if current_market.is_consignment_market? && @organization.org_type == 'S' %>
+  <% if current_market.is_consignment_market? && @organization.supplier? %>
   <div class="row row--field">
     <div class="field column column--half column--guttered">
       <%= f.label :qb_check_name, "QuickBooks Check Name" %><br/>

--- a/app/views/products/alternative_order_page.html.erb
+++ b/app/views/products/alternative_order_page.html.erb
@@ -1,6 +1,6 @@
 <%
   if !policy(:all_supplier).index?
-     supplier_id = current_market.organizations.where("org_type = 'S'")[0].id
+     supplier_id = current_market.organizations.where(org_type: Organization::TYPE_SUPPLIER)[0].id
   end
   current_supplier_id = @current_supplier.try(:id) || 0
 %>

--- a/lib/imports/product_helpers.rb
+++ b/lib/imports/product_helpers.rb
@@ -43,7 +43,12 @@ module Imports
 			begin
 				mkt = Market.find_by_subdomain(market_subdomain)
 				user = User.find(current_user.to_i)
-				org = user.managed_organizations_within_market(mkt).where(name: "#{organization_name.strip}", org_type: 'S')
+				org = user.
+                managed_organizations_within_market(mkt).
+                where(
+                  name: "#{organization_name.strip}",
+                  org_type: Organization::TYPE_SUPPLIER
+                )
 
 				#unless user.admin? || user.markets.include?(mkt)
 				#	return nil
@@ -169,7 +174,7 @@ module Imports
 
 				end
 
-			end # end the major if/else/end 
+			end # end the major if/else/end
 			# (update or not, basically, wherein the additional unit/line is handled inside each case in the unless stmts)
 		end # end def.self_create_product_from_hash
 

--- a/lib/tasks/production-copy.rake
+++ b/lib/tasks/production-copy.rake
@@ -48,10 +48,7 @@ namespace :production_copy do
     include CloneProductionHelper
     connect_production_copy
     cleanse_production_copy
-
-
   end
-
 
   desc "Copy the production S3 bucket to a target env"
   task :bucket, [:env] do |_, args|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -196,7 +196,6 @@ FactoryBot.define do
     allow_credit_cards     true
     default_allow_purchase_orders   false
     default_allow_credit_cards      true
-    auto_activate_organizations     false
     product_label_format 4
     print_multiple_labels_per_item false
     alternative_order_page         false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -393,7 +393,7 @@ FactoryBot.define do
   factory :organization do
     sequence(:name) {|n| "Organization #{n}" }
     can_sell true
-    org_type 'S'
+    org_type Organization::TYPE_SUPPLIER
     show_profile true
     allow_purchase_orders true
     allow_credit_cards    true
@@ -404,22 +404,22 @@ FactoryBot.define do
     payment_model         'buysell'
 
     trait :admin do
-      org_type 'A'
+      org_type Organization::TYPE_ADMIN
     end
 
     trait :market do
       plan                { create(:plan, :grow) }
-      org_type 'M'
+      org_type Organization::TYPE_MARKET
     end
 
     trait :seller do
       can_sell true
-      org_type 'S'
+      org_type Organization::TYPE_SUPPLIER
     end
 
     trait :buyer do
       can_sell false
-      org_type 'B'
+      org_type Organization::TYPE_BUYER
     end
 
     trait :single_location do

--- a/spec/interactors/send_fresh_sheet_spec.rb
+++ b/spec/interactors/send_fresh_sheet_spec.rb
@@ -1,126 +1,125 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe SendFreshSheet do
 
-  let!(:market) { create(:market, name: "Mad Dog Farm n Fry", delivery_schedules: [create(:delivery_schedule)]) }
-  let(:note) { "B flat" } #lol
+  let!(:market) { create(:market, name: 'Mad Dog Farm n Fry', delivery_schedules: [create(:delivery_schedule)]) }
+  let(:note) { 'B flat' } #lol
 
-  it "sends test emails" do
+  it 'sends test emails' do
     context = SendFreshSheet.perform(
       market: market,
-      commit: "Send Test",
-      email: "hossnfeffer@example.com",
+      commit: 'Send Test',
+      email: 'hossnfeffer@example.com',
       note: note)
     expect(context.success?).to eq(true)
-    expect(context.notice).to eq("Successfully sent a test to hossnfeffer@example.com")
+    expect(context.notice).to eq('Successfully sent a test to hossnfeffer@example.com')
 
     mail = ActionMailer::Base.deliveries.shift
     expect(mail).to be
 
-    assert_fresh_sheet_sent_to mail, market, "hossnfeffer@example.com", note
+    assert_fresh_sheet_sent_to mail, market, 'hossnfeffer@example.com', note
   end
 
-  context "sending to subscribers" do
-    let(:fresh_subscription) { create(:subscription_type, keyword: SubscriptionType::Keywords::FreshSheet, name: "Test Fresh!") }
+  context 'sending to subscribers' do
+    let(:fresh_subscription) { create(:subscription_type, keyword: SubscriptionType::Keywords::FreshSheet, name: 'Test Fresh!') }
 
-    let(:subscribed_buyer) do
+    let!(:subscribed_buyer) do
       user = create(:user, :buyer)
       create(:organization, :buyer, users:[user], markets:[market])
       user.subscribe_to(fresh_subscription)
       user
     end
 
-    let(:subscribed_supplier) do
+    let!(:subscribed_supplier) do
       user = create(:user, :supplier)
       create(:organization, :seller, users:[user], markets:[market])
       user.subscribe_to(fresh_subscription)
       user
     end
 
+    it 'should set success in the interactor context' do
+      context = SendFreshSheet.perform(market: market, commit: 'Send to Everyone Now', note: note)
+      expect(context.success?).to eq(true)
+      expect(context.notice).to eq('Successfully sent the Fresh Sheet')
+    end
 
-    context "sends Fresh Sheet emails to all users in the given market who subscribe to Fresh Sheets" do
+    it 'should have valid data in the emails' do
+      SendFreshSheet.perform(market: market, commit: 'Send to Everyone Now', note: note)
+      mails = ActionMailer::Base.deliveries
+      mail1 = mails.select do |m| m.to.first == subscribed_buyer.email end.first
+      assert_fresh_sheet_sent_to mail1, market, subscribed_buyer.email, note
+
+      mail2 = mails.select do |m| m.to.first == subscribed_supplier.email end.first
+      assert_fresh_sheet_sent_to mail2, market, subscribed_supplier.email, note
+    end
+
+    context 'when there unconfirmed users for the market' do
       before :each do
-        subscribed_buyer
-        subscribed_supplier
+        subscribed_buyer.update_column(:confirmed_at, nil)
       end
-
-      it "should set success in the context" do
-        context = SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
-        expect(context.success?).to eq(true)
-        expect(context.notice).to eq("Successfully sent the Fresh Sheet")
-      end
-
-      it "should have valid data in the emails" do
-        SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
+      it 'should not send to unconfirmed users' do
+        SendFreshSheet.perform(market: market, commit: 'Send to Everyone Now', note: note)
         mails = ActionMailer::Base.deliveries
-        mail1 = mails.select do |m| m.to.first == subscribed_buyer.email end.first
-        assert_fresh_sheet_sent_to mail1, market, subscribed_buyer.email, note
-
-        mail2 = mails.select do |m| m.to.first == subscribed_supplier.email end.first
-        assert_fresh_sheet_sent_to mail2, market, subscribed_supplier.email, note
+        emails = mails.map(&:to).map do |recips| recips.first end
+        expect(emails).not_to include(subscribed_buyer.email)
       end
+    end
 
-      context "when there unconfirmed users for the market" do
-        before :each do
-          subscribed_buyer.update_column(:confirmed_at, nil)
-        end
-        it "should not send to unconfirmed users" do
-          SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
-          mails = ActionMailer::Base.deliveries
-          emails = mails.map(&:to).map do |recips| recips.first end
-          expect(emails).not_to include(subscribed_buyer.email)
-        end
+    context 'when market users have been deactivated from an organization' do
+      before :each do
+        UserOrganization.where(user_id: subscribed_buyer.id).update_all(enabled: false)
       end
-
-      context "when some market users have been deactivated from an organization" do
-        before :each do
-          UserOrganization.where(user_id: subscribed_buyer.id).update_all(enabled: false)
-        end
-        it "should not send to markets users deactivated from organization" do
-          SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
-          mails = ActionMailer::Base.deliveries
-          emails = mails.map(&:to).map do |recips| recips.first end
-          expect(emails).not_to include(subscribed_buyer.email)
-        end
+      it 'should not send to markets users deactivated from organization' do
+        SendFreshSheet.perform(market: market, commit: 'Send to Everyone Now', note: note)
+        mails = ActionMailer::Base.deliveries
+        emails = mails.map(&:to).map do |recips| recips.first end
+        expect(emails).not_to include(subscribed_buyer.email)
       end
+    end
 
-      context "there exists users in other markets" do
-        let!(:subscriber_in_other_market) do
-          user = create(:user, :buyer)
-          create(:organization, :buyer, users:[user], markets:[create(:market)])
-          user.subscribe_to(fresh_subscription)
-          user
-        end
-        it "should not send to users only subscribed to other markets" do
-          SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
-          mails = ActionMailer::Base.deliveries
-          emails = mails.map(&:to).map do |recips| recips.first end
-          expect(emails).to_not contain_exactly(subscriber_in_other_market.email)
-        end
+    context 'when an organization has been disabled' do
+      it 'should not send to user who is only linked to market via a disabled organization'
+
+      it 'should send to a user who has an active organization and an inactive organization'
+
+    end
+
+    context 'there exists users in other markets' do
+      let!(:subscriber_in_other_market) do
+        user = create(:user, :buyer)
+        create(:organization, :buyer, users:[user], markets:[create(:market)])
+        user.subscribe_to(fresh_subscription)
+        user
       end
+      it 'should not send to users only subscribed to other markets' do
+        SendFreshSheet.perform(market: market, commit: 'Send to Everyone Now', note: note)
+        mails = ActionMailer::Base.deliveries
+        emails = mails.map(&:to).map do |recips| recips.first end
+        expect(emails).to_not contain_exactly(subscriber_in_other_market.email)
+      end
+    end
 
-      context "there are unsubscribed users in the market" do
-        let!(:unsubscribed_buyer) do
-          user = create(:user, :buyer)
-          create(:organization, :buyer, users:[user], markets:[market])
-          user.subscribe_to(fresh_subscription)
-          user.unsubscribe_from(fresh_subscription)
-          user
-        end
-        it "should not send to unsubscribed users" do
-          SendFreshSheet.perform(market: market, commit: "Send to Everyone Now", note: note)
-          mails = ActionMailer::Base.deliveries
-          emails = mails.map(&:to).map do |recips| recips.first end
-          expect(emails).to_not contain_exactly(unsubscribed_buyer.email)
-        end
+    context 'there are unsubscribed users in the market' do
+      let!(:unsubscribed_buyer) do
+        user = create(:user, :buyer)
+        create(:organization, :buyer, users:[user], markets:[market])
+        user.subscribe_to(fresh_subscription)
+        user.unsubscribe_from(fresh_subscription)
+        user
+      end
+      it 'should not send to unsubscribed users' do
+        SendFreshSheet.perform(market: market, commit: 'Send to Everyone Now', note: note)
+        mails = ActionMailer::Base.deliveries
+        emails = mails.map(&:to).map do |recips| recips.first end
+        expect(emails).to_not contain_exactly(unsubscribed_buyer.email)
       end
     end
   end
 
-  it "fails on bad commit value" do
-    context = SendFreshSheet.perform(market: market, commit: "oops bad", email:"hossnfeffer@example.com", note:note)
+  it 'fails on bad commit value' do
+    context = SendFreshSheet.perform(market: market, commit: 'oops bad', email: 'hossnfeffer@example.com', note:note)
     expect(context.failure?).to eq(true)
-    expect(context.error).to eq("Invalid action chosen")
+    expect(context.error).to eq('Invalid action chosen')
   end
 
   #

--- a/spec/interactors/send_fresh_sheet_spec.rb
+++ b/spec/interactors/send_fresh_sheet_spec.rb
@@ -4,38 +4,109 @@ describe SendFreshSheet do
 
   let!(:market) { create(:market, name: 'Mad Dog Farm n Fry', delivery_schedules: [create(:delivery_schedule)]) }
   let(:note) { 'B flat' } #lol
+  let(:fresh_subscription) do
+    create(:subscription_type,
+           keyword: SubscriptionType::Keywords::FreshSheet,
+           name: 'Test Fresh!')
+  end
 
-  it 'sends test emails' do
-    context = SendFreshSheet.perform(
-      market: market,
-      commit: 'Send Test',
-      email: 'hossnfeffer@example.com',
-      note: note)
-    expect(context.success?).to eq(true)
-    expect(context.notice).to eq('Successfully sent a test to hossnfeffer@example.com')
+  let!(:subscribed_buyer) do
+    user = create(:user, :buyer)
+    create(:organization, :buyer, users:[user], markets:[market])
+    user.subscribe_to(fresh_subscription)
+    user
+  end
 
-    mail = ActionMailer::Base.deliveries.shift
-    expect(mail).to be
+  let!(:subscribed_supplier) do
+    user = create(:user, :supplier)
+    create(:organization, :seller, users:[user], markets:[market])
+    user.subscribe_to(fresh_subscription)
+    user
+  end
 
-    assert_fresh_sheet_sent_to mail, market, 'hossnfeffer@example.com', note
+  context 'finding valid subscribers' do
+    subject(:interactor) do
+      interactor = SendFreshSheet.new
+      interactor.context[:market] = market
+      interactor
+    end
+
+    context 'when market users have been deactivated from an organization' do
+      before :each do
+        UserOrganization.where(user_id: subscribed_buyer.id).update_all(enabled: false)
+      end
+      it 'should not find deactivated organization users' do
+        target_users = subject.send(:fresh_sheet_subscribers)
+        expect(target_users).not_to include(subscribed_buyer)
+      end
+    end
+
+    context "when a user's only organization in the market is disabled" do
+      before :each do
+        subbed_org_ids = subscribed_buyer.organizations.pluck :id
+        Organization.where(id: subbed_org_ids).update_all(active: false)
+      end
+      it 'should not find the user' do
+        target_users = subject.send(:fresh_sheet_subscribers)
+        expect(target_users).not_to include(subscribed_buyer)
+      end
+    end
+
+    context "when a user has active and inactive organizations in the market" do
+      before :each do
+        inactive_org = create(:organization,
+                              :buyer,
+                              users:[subscribed_buyer],
+                              markets:[market],
+                              active: false
+                             )
+        subscribed_buyer.organizations << inactive_org
+      end
+      it 'should find the user' do
+        target_users = subject.send(:fresh_sheet_subscribers)
+        expect(target_users).to include(subscribed_supplier)
+      end
+    end
+
+    context 'when users exist in other markets' do
+      let!(:subscriber_in_other_market) do
+        user = create(:user, :buyer)
+        create(:organization, :buyer, users:[user], markets:[create(:market)])
+        user.subscribe_to(fresh_subscription)
+        user
+      end
+      it 'should not find users only belonging to other markets' do
+        target_users = subject.send(:fresh_sheet_subscribers)
+        expect(target_users).not_to include(subscriber_in_other_market.email)
+      end
+    end
+
+    context 'when there are unsubscribed users in the market' do
+      let!(:unsubscribed_buyer) do
+        user = create(:user, :buyer)
+        create(:organization, :buyer, users:[user], markets:[market])
+        user.subscribe_to(fresh_subscription)
+        user.unsubscribe_from(fresh_subscription)
+        user
+      end
+      it 'should not find unsubscribed users' do
+        target_users = subject.send(:fresh_sheet_subscribers)
+        expect(target_users).not_to include(unsubscribed_buyer)
+      end
+    end
+
+    context 'when there unconfirmed users for the market' do
+      before :each do
+        subscribed_buyer.update_column(:confirmed_at, nil)
+      end
+      it 'should not find unconfirmed users' do
+        target_users = subject.send(:fresh_sheet_subscribers)
+        expect(target_users).not_to include(subscribed_buyer)
+      end
+    end
   end
 
   context 'sending to subscribers' do
-    let(:fresh_subscription) { create(:subscription_type, keyword: SubscriptionType::Keywords::FreshSheet, name: 'Test Fresh!') }
-
-    let!(:subscribed_buyer) do
-      user = create(:user, :buyer)
-      create(:organization, :buyer, users:[user], markets:[market])
-      user.subscribe_to(fresh_subscription)
-      user
-    end
-
-    let!(:subscribed_supplier) do
-      user = create(:user, :supplier)
-      create(:organization, :seller, users:[user], markets:[market])
-      user.subscribe_to(fresh_subscription)
-      user
-    end
 
     it 'should set success in the interactor context' do
       context = SendFreshSheet.perform(market: market, commit: 'Send to Everyone Now', note: note)
@@ -53,79 +124,29 @@ describe SendFreshSheet do
       assert_fresh_sheet_sent_to mail2, market, subscribed_supplier.email, note
     end
 
-    context 'when there unconfirmed users for the market' do
-      before :each do
-        subscribed_buyer.update_column(:confirmed_at, nil)
-      end
-      it 'should not send to unconfirmed users' do
-        SendFreshSheet.perform(market: market, commit: 'Send to Everyone Now', note: note)
-        mails = ActionMailer::Base.deliveries
-        emails = mails.map(&:to).map do |recips| recips.first end
-        expect(emails).not_to include(subscribed_buyer.email)
-      end
-    end
-
-    context 'when market users have been deactivated from an organization' do
-      before :each do
-        UserOrganization.where(user_id: subscribed_buyer.id).update_all(enabled: false)
-      end
-      it 'should not send to markets users deactivated from organization' do
-        SendFreshSheet.perform(market: market, commit: 'Send to Everyone Now', note: note)
-        mails = ActionMailer::Base.deliveries
-        emails = mails.map(&:to).map do |recips| recips.first end
-        expect(emails).not_to include(subscribed_buyer.email)
-      end
-    end
-
-    context 'when an organization has been disabled' do
-      it 'should not send to user who is only linked to market via a disabled organization'
-
-      it 'should send to a user who has an active organization and an inactive organization'
-
-    end
-
-    context 'there exists users in other markets' do
-      let!(:subscriber_in_other_market) do
-        user = create(:user, :buyer)
-        create(:organization, :buyer, users:[user], markets:[create(:market)])
-        user.subscribe_to(fresh_subscription)
-        user
-      end
-      it 'should not send to users only subscribed to other markets' do
-        SendFreshSheet.perform(market: market, commit: 'Send to Everyone Now', note: note)
-        mails = ActionMailer::Base.deliveries
-        emails = mails.map(&:to).map do |recips| recips.first end
-        expect(emails).to_not contain_exactly(subscriber_in_other_market.email)
-      end
-    end
-
-    context 'there are unsubscribed users in the market' do
-      let!(:unsubscribed_buyer) do
-        user = create(:user, :buyer)
-        create(:organization, :buyer, users:[user], markets:[market])
-        user.subscribe_to(fresh_subscription)
-        user.unsubscribe_from(fresh_subscription)
-        user
-      end
-      it 'should not send to unsubscribed users' do
-        SendFreshSheet.perform(market: market, commit: 'Send to Everyone Now', note: note)
-        mails = ActionMailer::Base.deliveries
-        emails = mails.map(&:to).map do |recips| recips.first end
-        expect(emails).to_not contain_exactly(unsubscribed_buyer.email)
-      end
+    it 'fails on bad commit value' do
+      context = SendFreshSheet.perform(market: market, commit: 'oops bad', email: 'hossnfeffer@example.com', note:note)
+      expect(context.failure?).to eq(true)
+      expect(context.error).to eq('Invalid action chosen')
     end
   end
 
-  it 'fails on bad commit value' do
-    context = SendFreshSheet.perform(market: market, commit: 'oops bad', email: 'hossnfeffer@example.com', note:note)
-    expect(context.failure?).to eq(true)
-    expect(context.error).to eq('Invalid action chosen')
+  it 'sends test emails' do
+    context = SendFreshSheet.perform(
+      market: market,
+      commit: 'Send Test',
+      email: 'hossnfeffer@example.com',
+      note: note)
+    expect(context.success?).to eq(true)
+    expect(context.notice).to eq('Successfully sent a test to hossnfeffer@example.com')
+
+    mail = ActionMailer::Base.deliveries.shift
+    expect(mail).to be
+
+    assert_fresh_sheet_sent_to mail, market, 'hossnfeffer@example.com', note
   end
 
-  #
   # HELPERS
-  #
-
   def assert_fresh_sheet_sent_to(mail,market,sent_to,note)
     expect(mail).to be
     expect(mail.to.first).to eq(sent_to)

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -23,39 +23,41 @@ describe Registration do
     Registration.new(registration_attrs)
   }
 
-  context "market does have 'auto-activate organizations' enabled" do
-    let(:market) { create(:market,  auto_activate_organizations: true ) }
-    it "should have a registration organization is enabled" do
-      registration.save
-      org = registration.organization
-      user = registration.user
-      expect(user.enabled_for_organization? org).to be true
-      expect(org.active?).to be true
-    end
-  end
-
-  context "market does *not* have 'auto-activate organizations' enabled" do
-    it "should have a registered organization that is not be enabled" do
-      registration.save
-      org = registration.organization
-      user = registration.user
-      expect(user.enabled_for_organization? org).to be true
-      expect(org.active?).to be false
-    end
-  end
-
-  describe "address_label" do
-    it "saves Location name based on address_label" do
-      label = "The Address Label"
-      registration_attrs[:address_label] = label
-      expect(registration.save).to be true
-      expect(registration.organization.locations.first.name).to eq(label)
+  describe '.save' do
+    context "market does have 'auto-activate organizations' enabled" do
+      let(:market) { create(:market,  auto_activate_organizations: true ) }
+      it "should have a registration organization is enabled" do
+        registration.save
+        org = registration.organization
+        user = registration.user
+        expect(user.enabled_for_organization? org).to be true
+        expect(org.active?).to be true
+      end
     end
 
-    it "defaults to 'Default Address' when saving a new Location" do
-      registration_attrs[:address_label] = nil
-      expect(registration.save).to be true
-      expect(registration.organization.locations.first.name).to eq("Default Address")
+    context "market does *not* have 'auto-activate organizations' enabled" do
+      it "should have a registered organization that is not be enabled" do
+        registration.save
+        org = registration.organization
+        user = registration.user
+        expect(user.enabled_for_organization? org).to be true
+        expect(org.active?).to be false
+      end
+    end
+
+    describe "address_label" do
+      it "saves Location name based on address_label" do
+        label = "The Address Label"
+        registration_attrs[:address_label] = label
+        expect(registration.save).to be true
+        expect(registration.organization.locations.first.name).to eq(label)
+      end
+
+      it "defaults to 'Default Address' when saving a new Location" do
+        registration_attrs[:address_label] = nil
+        expect(registration.save).to be true
+        expect(registration.organization.locations.first.name).to eq("Default Address")
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,15 +1,15 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe User do
-  describe "roles" do
+  describe 'roles' do
 
-    describe "#can_manage?" do
+    describe '#can_manage?' do
       let(:market) { create(:market) }
       let(:org) { create(:organization) }
       let(:other_user) { create(:user) }
       let(:user) { create(:user) }
 
-      it "delegates to the correct method" do
+      it 'delegates to the correct method' do
         expect(user).to receive(:can_manage_organization?).with(org)
         user.can_manage?(org)
 
@@ -21,48 +21,48 @@ describe User do
       end
     end
 
-    describe "#can_manage_organization?" do
+    describe '#can_manage_organization?' do
       let(:org) { create(:organization) }
 
-      context "when user is an admin" do
+      context 'when user is an admin' do
         let(:user) { create(:user, :admin) }
 
-        it "returns true" do
+        it 'returns true' do
           expect(user.can_manage_organization?(org)).to be true
         end
       end
 
-      context "when the user is a market manager" do
+      context 'when the user is a market manager' do
         let(:market_manager) { create(:user, :market_manager) }
         let(:market) { market_manager.managed_markets.first }
 
-        context "and the org is in their managed market" do
+        context 'and the org is in their managed market' do
           before do
             market.organizations << org
           end
 
-          it "returns true" do
+          it 'returns true' do
             expect(market_manager.can_manage_organization?(org)).to be true
           end
         end
 
-        context "and the org is not in their managed market" do
-          it "returns false" do
+        context 'and the org is not in their managed market' do
+          it 'returns false' do
             expect(market_manager.can_manage_organization?(org)).to be false
           end
         end
       end
 
-      context "user does not manage any market" do
+      context 'user does not manage any market' do
         let(:user) { create(:user) }
 
-        it "returns false" do
+        it 'returns false' do
           expect(user.can_manage_organization?(org)).to be false
         end
       end
     end
 
-    describe "#can_manage_user?" do
+    describe '#can_manage_user?' do
       let!(:org1)   { create(:organization, :seller, markets: [market1], users: [user1, user2]) }
       let!(:org2)   { create(:organization, :seller, markets: [market2], users: [user3, user4]) }
       let!(:org3)   { create(:organization, :seller, markets: [market2], users: [user5]) }
@@ -79,39 +79,39 @@ describe User do
       context "admin" do
         let!(:admin) { create(:user, :admin) }
 
-        it "is true for everyone" do
+        it 'is true for everyone' do
           [user1, user2, user3, user4].each do |u|
             expect(admin.can_manage_user?(u)).to be_truthy
           end
         end
       end
 
-      context "market manager" do
+      context 'market manager' do
         let!(:market_manager) { create(:user, :market_manager, managed_markets: [market1]) }
 
-        it "can manage users in organizations in their market" do
+        it 'can manage users in organizations in their market' do
           expect(market_manager.can_manage_user?(user1)).to be_truthy
           expect(market_manager.can_manage_user?(user2)).to be_truthy
           expect(market_manager.can_manage_user?(user3)).to be_falsy
           expect(market_manager.can_manage_user?(user4)).to be_falsy
         end
 
-        context "managing multiple markets" do
+        context 'managing multiple markets' do
           let!(:market_manager) { create(:user, :market_manager, managed_markets: [market1, market2]) }
 
-          it "can manage users in organizations in all their markets" do
+          it 'can manage users in organizations in all their markets' do
             expect(market_manager.can_manage_user?(user1)).to be_truthy
             expect(market_manager.can_manage_user?(user2)).to be_truthy
             expect(market_manager.can_manage_user?(user3)).to be_truthy
             expect(market_manager.can_manage_user?(user4)).to be_truthy
           end
 
-          context "and a user has been suspended" do
+          context 'and a user has been suspended' do
             before do
               suspend_user(user: user1, org: user1.organizations.first)
             end
 
-            it "can still manage that suspended user" do
+            it 'can still manage that suspended user' do
               expect(market_manager.can_manage_user?(user1)).to be_truthy
               expect(market_manager.can_manage_user?(user2)).to be_truthy
               expect(market_manager.can_manage_user?(user3)).to be_truthy
@@ -121,10 +121,10 @@ describe User do
         end
       end
 
-      context "buyer/seller" do
+      context 'buyer/seller' do
         let!(:buyer) { create(:user, :supplier, organizations: [org1, org3]) }
 
-        it "can manage users in organizations they belong to" do
+        it 'can manage users in organizations they belong to' do
           expect(buyer.can_manage_user?(user1)).to be_truthy
           expect(buyer.can_manage_user?(user2)).to be_truthy
           expect(buyer.can_manage_user?(user3)).to be_falsy
@@ -150,8 +150,8 @@ describe User do
       expect(user.admin?).to be false
     end
 
-    context "#seller?" do
-      it "returns true if the user is a member of any selling organizations" do
+    context '#seller?' do
+      it 'returns true if the user is a member of any selling organizations' do
         market_org = create(:organization, :market)
         market = create(:market, organization: market_org)
         org = create(:organization, :seller, markets: [market])
@@ -159,12 +159,12 @@ describe User do
         expect(user).to be_seller
       end
 
-      it "returns false if the user is not a member of any selling organizations" do
+      it 'returns false if the user is not a member of any selling organizations' do
         user = create(:user, :buyer, organizations: [create(:organization, :buyer)])
         expect(user).not_to be_seller
       end
 
-      it "returns false if user is an admin" do
+      it 'returns false if user is an admin' do
         market_org = create(:organization, :market)
         market = create(:market, organization: market_org)
         org = create(:organization, :seller, markets: [market])
@@ -176,27 +176,27 @@ describe User do
 
     end
 
-    context "#buyer_only?" do
-      it "returns true if the user is only a buyer" do
+    context '#buyer_only?' do
+      it 'returns true if the user is only a buyer' do
         user = create(:user, :buyer)
         org = create(:organization, :buyer)
         user.organizations << org
         expect(user).to be_buyer_only
       end
 
-      it "returns false if the user is a seller" do
+      it 'returns false if the user is a seller' do
         user = build(:user, :supplier)
         allow(user).to receive(:seller?).and_return(true)
         expect(user).not_to be_buyer_only
       end
 
-      it "returns false if the user is a market manager" do
+      it 'returns false if the user is a market manager' do
         user = build(:user, :market_manager)
         allow(user).to receive(:market_manager?).and_return(true)
         expect(user).not_to be_buyer_only
       end
 
-      it "returns false if the user is an admin" do
+      it 'returns false if the user is an admin' do
         user = create(:user, :buyer)
         org = create(:organization, :buyer)
         user.organizations << org
@@ -207,9 +207,9 @@ describe User do
     end
   end
 
-  describe "managed_organizations" do
+  describe 'managed_organizations' do
 
-    context "for an admin" do
+    context 'for an admin' do
       let!(:user) { create(:user, :admin) }
       let!(:market_org1) { create(:organization, :market) }
       let!(:market1) { create(:market, organization: market_org1) }
@@ -219,17 +219,17 @@ describe User do
       let!(:org2) { create(:organization, :seller, markets: [market2]) }
       let(:result) { user.managed_organizations }
 
-      it "returns a scope with all organizations" do
+      it 'returns a scope with all organizations' do
         expect(result.count).to eq(2)
 
         expect(result).to include(org1)
         expect(result).to include(org2)
       end
 
-      context "cross selling organizations belonging to a market" do
+      context 'cross selling organizations belonging to a market' do
         let!(:cross_sell_org) { create(:organization, markets: [market2]).tap {|o| o.market_organizations.create(market: market1, cross_sell_origin_market: market2) } }
 
-        it "returns unique results for all organizations" do
+        it 'returns unique results for all organizations' do
           expect(result.count).to eql(3)
           expect(result).to include(org1)
           expect(result).to include(org2)
@@ -238,16 +238,16 @@ describe User do
       end
     end
 
-    context "for a market manager" do
+    context 'for a market manager' do
 
 
-      let(:org1) { create(:organization, name: "Org 1") }
-      let(:org2) { create(:organization, name: "Org 2") }
-      let(:org3) { create(:organization, name: "Org 3") }
-      let(:org4) { create(:organization, name: "Org 4") }
-      let(:org5) { create(:organization, name: "Org 5") }
-      let(:org6) { create(:organization, name: "Org 6") }
-      let(:org7) { create(:organization, name: "Org 7") }
+      let(:org1) { create(:organization, name: 'Org 1') }
+      let(:org2) { create(:organization, name: 'Org 2') }
+      let(:org3) { create(:organization, name: 'Org 3') }
+      let(:org4) { create(:organization, name: 'Org 4') }
+      let(:org5) { create(:organization, name: 'Org 5') }
+      let(:org6) { create(:organization, name: 'Org 6') }
+      let(:org7) { create(:organization, name: 'Org 7') }
 
       let(:market1) { create(:market, organizations:[org1,org5]) }
       let(:market2) { create(:market, organizations:[org2,org7]) }
@@ -271,32 +271,32 @@ describe User do
         org7.market_organizations.where(market_id: market2).soft_delete_all
       end
 
-      it "returns a chainable scope" do
+      it 'returns a chainable scope' do
         expect(user.managed_organizations).to be_a_kind_of(ActiveRecord::Relation)
       end
 
-      it "includes organizations in their managed markets" do
+      it 'includes organizations in their managed markets' do
         expect(user.managed_organizations).to include(org1, org2)
       end
 
-      it "includes organizations they directly belong to" do
+      it 'includes organizations they directly belong to' do
         expect(user.managed_organizations).to include(org4, org5)
       end
 
-      it "does not include organizations in other markets" do
+      it 'does not include organizations in other markets' do
         expect(user.managed_organizations).to_not include(org3)
       end
 
-      it "does not include organizations merely cross selling to the market" do
+      it 'does not include organizations merely cross selling to the market' do
         expect(user.managed_organizations).to_not include(org6)
       end
 
-      it "does not include organizations removed from the market" do
+      it 'does not include organizations removed from the market' do
         expect(user.managed_organizations).to_not include(org7)
       end
     end
 
-    context "for a user" do
+    context 'for a user' do
       let!(:user) { create(:user, organizations: [org1, org2]) }
       let!(:market) { create(:market) }
       let!(:market2) { create(:market) }
@@ -304,16 +304,16 @@ describe User do
       let!(:org1) { create(:organization, markets: [market]) }
       let!(:org2) { create(:organization, markets: [market2]) }
 
-      it "returns a scope for the organization memberships" do
+      it 'returns a scope for the organization memberships' do
         expect(user.managed_organizations).to eq(user.organizations)
       end
 
-      context "who has been suspended" do
+      context 'who has been suspended' do
         before do
           suspend_user(user: user, org: org1)
         end
 
-        it "returns a list of organizations which the user has not been suspended from" do
+        it 'returns a list of organizations which the user has not been suspended from' do
           expect(user.managed_organizations).to eq([org2])
         end
 
@@ -324,81 +324,81 @@ describe User do
     end
   end
 
-  describe "managed_organizations_within_market" do
-    let(:org1) { create(:organization, :buyer, name: "Org 1") }
-    let(:org2) { create(:organization, :buyer, name: "Org 2") }
-    let(:org3) { create(:organization, :buyer, name: "Org 3") }
-    let(:org4) { create(:organization, :buyer, name: "Org 4") }
-    let(:org5) { create(:organization, :buyer, name: "Org 5") }
+  describe 'managed_organizations_within_market' do
+    let(:org1) { create(:organization, :buyer, name: 'Org 1') }
+    let(:org2) { create(:organization, :buyer, name: 'Org 2') }
+    let(:org3) { create(:organization, :buyer, name: 'Org 3') }
+    let(:org4) { create(:organization, :buyer, name: 'Org 4') }
+    let(:org5) { create(:organization, :buyer, name: 'Org 5') }
 
     let!(:market1) { create(:market, organizations: [org1, org5]) }
     let!(:market2) { create(:market, organizations: [org2]) }
     let!(:market3) { create(:market, organizations: [org3, org4]) }
 
-    context "for an admin" do
+    context 'for an admin' do
       let(:user) { create(:user, :admin) }
 
-      it "returns a scope with all organizations for the market" do
+      it 'returns a scope with all organizations for the market' do
         expect(user.managed_organizations_within_market(market1)).to include(org1, org5)
         expect(user.managed_organizations_within_market(market1)).to_not include(org2, org3, org4)
       end
-      it "returns a scope with all organizations not deleted for the market" do
+      it 'returns a scope with all organizations not deleted for the market' do
         MarketOrganization.where(organization_id: org5.id, market_id: market1.id).first.update_attribute(:deleted_at, 1.day.ago)
         expect(user.managed_organizations_within_market(market1)).to include(org1)
         expect(user.managed_organizations_within_market(market1)).not_to include(org5)
       end
 
-      it "returns a scope with all organizations not_cross_selling for the market" do
+      it 'returns a scope with all organizations not_cross_selling for the market' do
         MarketOrganization.where(organization_id: org5.id, market_id: market1.id).first.update_attribute(:cross_sell_origin_market_id, true)
         expect(user.managed_organizations_within_market(market1)).to include(org1)
         expect(user.managed_organizations_within_market(market1)).not_to include(org5)
       end
     end
 
-    context "for a market manager" do
+    context 'for a market manager' do
       let(:user) { create(:user, :market_manager, managed_markets: [market1, market2], organizations: [org4, org5]) }
 
-      it "returns a chainable scope" do
+      it 'returns a chainable scope' do
         expect(user.managed_organizations_within_market(market1)).to be_a_kind_of(ActiveRecord::Relation)
       end
 
-      it "includes organizations in the market they manage" do
+      it 'includes organizations in the market they manage' do
         expect(user.managed_organizations_within_market(market1)).to include(org1, org5)
         expect(user.managed_organizations_within_market(market1)).to_not include(org2, org3, org4)
       end
 
-      it "includes their organizations in the market they do not manage" do
+      it 'includes their organizations in the market they do not manage' do
         expect(user.managed_organizations_within_market(market3)).to include(org4)
         expect(user.managed_organizations_within_market(market3)).to_not include(org1, org2, org3, org5)
       end
     end
 
-    context "for a user" do
+    context 'for a user' do
       let(:user) { create(:user, organizations: [org1, org5]) }
 
-      it "returns a scope for the organization memberships within the market" do
+      it 'returns a scope for the organization memberships within the market' do
         expect(user.managed_organizations_within_market(market1)).to include(org1, org5)
         expect(user.managed_organizations_within_market(market1)).to_not include(org2, org3, org4)
       end
 
-      it "returns a scope with all organizations not deleted for the market" do
+      it 'returns a scope with all organizations not deleted for the market' do
         MarketOrganization.where(organization_id: org5.id, market_id: market1.id).first.update_attribute(:deleted_at, 1.day.ago)
         expect(user.managed_organizations_within_market(market1)).to include(org1)
         expect(user.managed_organizations_within_market(market1)).not_to include(org5)
       end
 
-      it "returns a scope with all organizations not_cross_selling for the market" do
+      it 'returns a scope with all organizations not_cross_selling for the market' do
         MarketOrganization.where(organization_id: org5.id, market_id: market1.id).first.update_attribute(:cross_sell_origin_market_id, true)
         expect(user.managed_organizations_within_market(market1)).to include(org1)
         expect(user.managed_organizations_within_market(market1)).not_to include(org5)
       end
 
-      context "user is suspended from an organization" do
+      context 'user is suspended from an organization' do
         before do
           suspend_user(user: user, org: org1)
         end
 
-        it "will not return organizations a user is suspended from" do
+        it 'will not return organizations a user is suspended from' do
           expect(user.managed_organizations_within_market(market1)).to include(org5)
           expect(user.managed_organizations_within_market(market1)).not_to include(org1, org3, org4)
         end
@@ -406,16 +406,16 @@ describe User do
     end
   end
 
-  describe "markets" do
+  describe 'markets' do
     context "admin" do
       let(:user) { create(:user, :admin) }
 
-      it "returns all markets" do
+      it 'returns all markets' do
         expect(user.markets).to eq(Market.all)
       end
     end
 
-    context "market manager" do
+    context 'market manager' do
       let(:user) { create(:user, :market_manager) }
       let(:market1) { user.managed_markets.first }
       let(:market2) { create(:market) }
@@ -427,23 +427,23 @@ describe User do
         market2.organizations << org
       end
 
-      it "returns a relation object" do
+      it 'returns a relation object' do
         expect(user.markets).to be_kind_of(ActiveRecord::Relation)
       end
 
-      it "belongs to the markets they manage" do
+      it 'belongs to the markets they manage' do
         expect(user.markets).to include(market1)
       end
 
-      it "belongs to markets their organizations belong to" do
+      it 'belongs to markets their organizations belong to' do
         expect(user.markets).to include(market2)
       end
 
-      it "does not show markets for which they are not members" do
+      it 'does not show markets for which they are not members' do
         expect(user.markets).to_not include(market3)
       end
 
-      context "user is a  member of an organization which was deleted" do
+      context 'user is a  member of an organization which was deleted' do
         let!(:empty_market) { create(:market, organizations: [], managers: [user]) }
         let!(:deleted_organization) { create(:organization, markets: [empty_market]) }
 
@@ -452,14 +452,14 @@ describe User do
           mo.soft_delete
         end
 
-        it "still returns markets the user manages" do
+        it 'still returns markets the user manages' do
           expect(user.markets).to include(empty_market)
         end
       end
 
     end
 
-    context "user" do
+    context 'user' do
       let(:user) { create(:user) }
       let(:market1) { create(:market) }
       let(:market2) { create(:market) }
@@ -470,34 +470,34 @@ describe User do
         market1.organizations << org
       end
 
-      it "returns a relation object" do
+      it 'returns a relation object' do
         expect(user.markets).to be_kind_of(ActiveRecord::Relation)
       end
 
-      it "belongs to markets their organizations belong to" do
+      it 'belongs to markets their organizations belong to' do
         expect(user.markets).to include(market1)
       end
 
-      it "does not show markets for which they are not members" do
+      it 'does not show markets for which they are not members' do
         expect(user.markets).to_not include(market2)
       end
     end
   end
 
-  describe "managed_products" do
+  describe 'managed_products' do
     subject { user.managed_products }
 
-    context "for an admin" do
+    context 'for an admin' do
       let!(:user) { create(:user, :admin) }
 
-      xit "returns all products" do
+      xit 'returns all products' do
         Timecop.freeze do
           expect(subject).to eq(Product.visible.seller_can_sell.joins(organization: :market_organizations))
         end
       end
     end
 
-    context "for a market manager" do
+    context 'for a market manager' do
       let!(:user) { create(:user, :market_manager) }
       let!(:market1) { user.managed_markets.first }
       let!(:market2) { create(:market) }
@@ -507,24 +507,24 @@ describe User do
       let!(:prod2) { create(:product, organization: org2) }
       let!(:deleted_prod) { create(:product, organization: org1, deleted_at: 1.minute.ago) }
 
-      it "returns a scope" do
+      it 'returns a scope' do
         expect(subject).to be_kind_of(ActiveRecord::Relation)
       end
 
-      it "returned scope includes products for organizations in markets they manage" do
+      it 'returned scope includes products for organizations in markets they manage' do
         expect(subject).to include(prod1)
       end
 
-      it "returned scope does not include products for organizations in markets they do not manage" do
+      it 'returned scope does not include products for organizations in markets they do not manage' do
         expect(subject).to_not include(prod2)
       end
 
-      it "returned scope does not include deleted products" do
+      it 'returned scope does not include deleted products' do
         expect(subject).to_not include(deleted_prod)
       end
     end
 
-    context "for a user" do
+    context 'for a user' do
       let!(:user) { create(:user) }
       let!(:market1) { create(:market) }
       let!(:org1) { create(:organization, markets: [market1], users: [user]) }
@@ -533,74 +533,74 @@ describe User do
       let!(:prod2) { create(:product, organization: org2) }
       let!(:deleted_prod) { create(:product, organization: org1, deleted_at: 1.minute.ago) }
 
-      it "returns a scope" do
+      it 'returns a scope' do
         expect(subject).to be_kind_of(ActiveRecord::Relation)
       end
 
-      it "returned scope includes products for organizations they belong to" do
+      it 'returned scope includes products for organizations they belong to' do
         expect(subject).to include(prod1)
       end
 
-      it "returned scope does not include products for organization they do not belong to" do
+      it 'returned scope does not include products for organization they do not belong to' do
         expect(subject).to_not include(prod2)
       end
 
-      it "returned scope does not include deleted products" do
+      it 'returned scope does not include deleted products' do
         expect(subject).to_not include(deleted_prod)
       end
     end
   end
 
-  describe "token authentication" do
+  describe 'token authentication' do
     let!(:user) { create(:user) }
 
-    describe "#auth_token" do
-      it "returns a token string" do
+    describe '#auth_token' do
+      it 'returns a token string' do
         expect(user.auth_token).to be_a(String)
       end
     end
 
-    describe ".for_auth_token" do
-      it "returns the user for a valid token" do
+    describe '.for_auth_token' do
+      it 'returns the user for a valid token' do
         expect(User.for_auth_token(user.auth_token)).to eq(user)
       end
 
-      it "returns nil for a blank token" do
+      it 'returns nil for a blank token' do
         expect(User.for_auth_token(nil)).to be_nil
-        expect(User.for_auth_token("")).to be_nil
+        expect(User.for_auth_token('')).to be_nil
       end
 
-      it "returns nil for an expired token" do
+      it 'returns nil for an expired token' do
         expect(User.for_auth_token(user.auth_token(-10.minutes))).to be_nil
       end
 
-      it "return nil for an invalid token" do
-        expect(User.for_auth_token("not-gonna-do-it")).to be_nil
+      it 'return nil for an invalid token' do
+        expect(User.for_auth_token('not-gonna-do-it')).to be_nil
       end
     end
   end
 
-  context "oranizations scopes" do
+  context 'oranizations scopes' do
     let!(:market) { create(:market) }
     let!(:user) { create(:user) }
     let!(:org1) { create(:organization, users: [user], markets: [market]) }
     let!(:org2) { create(:organization, users: [user], markets: [market]) }
 
-    describe "#organizations" do
+    describe '#organizations' do
       let(:result) { user.organizations }
 
-      it "returns the organizations the user belongs to" do
+      it 'returns the organizations the user belongs to' do
         expect(result.count).to eql(2)
         expect(result).to include(org1)
         expect(result).to include(org2)
       end
 
-      context "when the user has been suspended from an organization" do
+      context 'when the user has been suspended from an organization' do
         before do
           suspend_user(user: user, org: org1)
         end
 
-        it "does not return organizations where the user is suspended" do
+        it 'does not return organizations where the user is suspended' do
           expect(result.count).to eql(1)
           expect(result).not_to include(org1)
           expect(result).to include(org2)
@@ -608,15 +608,15 @@ describe User do
       end
     end
 
-    describe "#organizations_including_suspended" do
+    describe '#organizations_including_suspended' do
       let(:result) { user.organizations_including_suspended }
 
       before do
         suspend_user(user: user, org: org1)
       end
 
-      context "when the user has been suspended from an organization" do
-        it "returns all organizations a user is associated with including suspended" do
+      context 'when the user has been suspended from an organization' do
+        it 'returns all organizations a user is associated with including suspended' do
           expect(result.count).to eql(2)
           expect(result).to include(org1)
           expect(result).to include(org2)
@@ -624,13 +624,13 @@ describe User do
       end
     end
 
-    describe "#suspended_organizations" do
+    describe '#suspended_organizations' do
       let(:result) { user.suspended_organizations }
       before do
         suspend_user(user: user, org: org1)
       end
 
-      it "returns all organizations a user is suspended from" do
+      it 'returns all organizations a user is suspended from' do
         expect(result.count).to eql(1)
 
         expect(result).to include(org1)
@@ -639,7 +639,7 @@ describe User do
     end
   end
 
-  describe ".in_market scope" do
+  describe '.in_market scope' do
     let!(:market) { create(:market) }
     let!(:market2) { create(:market) }
 
@@ -656,29 +656,42 @@ describe User do
     let!(:buyer_org2_again) { create(:organization, :buyer, markets: [market2], users: [user2]) }
     let!(:buyer_org5) { create(:organization, :buyer, markets: [market2], users: [user5]) }
 
-    it "gets all the Users in a Market" do
+    it 'gets all the Users in a Market' do
       users = User.in_market(market)
       expect(users).to contain_exactly(user1,user2,user3)
     end
 
-    it "can accept an id instead of a Market instance" do
+    it 'can accept an id instead of a Market instance' do
       expect(User.in_market(market.id)).to contain_exactly(user1,user2,user3)
     end
 
-    it "respects deleted organization-market links" do
-      buyer_org2.market_organizations.find_by(market: market).soft_delete
-      expect(User.in_market(market)).to contain_exactly(user1,user3)
+    context 'with a user only belonging to inactive organization' do
+      before do
+        buyer_org1.update_attribute(:active, false)
+      end
+      it 'does not include users from inactive orgs' do
+        expect(User.in_market(market.id)).to contain_exactly(user2,user3)
+      end
+    end
+
+    context 'wieth a soft deleted organization' do
+      before do
+        buyer_org2.market_organizations.find_by(market: market).soft_delete
+      end
+      it 'respects deleted organization-market links' do
+        expect(User.in_market(market)).to contain_exactly(user1,user3)
+      end
     end
   end
 
-  context "users with subscriptions" do
+  context 'users with subscriptions' do
     let!(:user1)  { create(:user, :supplier) }
     let!(:user2)  { create(:user, :supplier) }
     let!(:user3)  { create(:user, :supplier) }
     let!(:user4)  { create(:user, :supplier) }
 
-    let!(:ads) { create(:subscription_type, name: "Advertisements", keyword: "ads") }
-    let!(:notes) { create(:subscription_type, name: "Note Notices", keyword: "notes") }
+    let!(:ads) { create(:subscription_type, name: 'Advertisements', keyword: 'ads') }
+    let!(:notes) { create(:subscription_type, name: 'Note Notices', keyword: 'notes') }
 
     before do
       user1.subscribe_to ads
@@ -687,23 +700,23 @@ describe User do
       user3.subscribe_to notes
     end
 
-    describe ".subscribed_to scope" do
-      it "includes users who are subscribed to the given subscriptio type" do
+    describe '.subscribed_to scope' do
+      it 'includes users who are subscribed to the given subscriptio type' do
         expect(User.subscribed_to(ads)).to contain_exactly(user1,user2)
         expect(User.subscribed_to(notes)).to contain_exactly(user2,user3)
       end
 
-      it "accepts a subscription type keyword in lieu of SubscriptionType instance" do
-        expect(User.subscribed_to("ads")).to contain_exactly(user1,user2)
-        expect(User.subscribed_to("notes")).to contain_exactly(user2,user3)
+      it 'accepts a subscription type keyword in lieu of SubscriptionType instance' do
+        expect(User.subscribed_to('ads')).to contain_exactly(user1,user2)
+        expect(User.subscribed_to('notes')).to contain_exactly(user2,user3)
       end
 
-      it "accepts a subscription type id in lieu of SubscriptionType instance" do
+      it 'accepts a subscription type id in lieu of SubscriptionType instance' do
         expect(User.subscribed_to(ads.id)).to contain_exactly(user1,user2)
         expect(User.subscribed_to(notes.id)).to contain_exactly(user2,user3)
       end
 
-      it "respects soft-deleted subscriptions" do
+      it 'respects soft-deleted subscriptions' do
         # user2 unsubscribes from ads:
         user2.subscriptions.find_by(subscription_type: ads).soft_delete
         expect(User.subscribed_to(ads)).to contain_exactly(user1)
@@ -721,8 +734,8 @@ describe User do
       end
     end
 
-    describe "#subscribe_to and #unsubscribe_from" do
-      it "creates and soft-deletes links" do
+    describe '#subscribe_to and #unsubscribe_from' do
+      it 'creates and soft-deletes links' do
         expect(User.subscribed_to(ads)).not_to include(user3)
 
         # subscribe to ads:
@@ -749,18 +762,18 @@ describe User do
 
     end
 
-    describe "#active_subscriptions" do
+    describe '#active_subscriptions' do
       let!(:ads_sub) { user2.subscriptions.find_by(subscription_type: ads) }
       let!(:notes_sub) { user2.subscriptions.find_by(subscription_type: notes) }
 
-      it "returns non-deleted subscriptions" do
+      it 'returns non-deleted subscriptions' do
         ads_sub = user2.subscriptions.find_by(subscription_type: ads)
         notes_sub = user2.subscriptions.find_by(subscription_type: notes)
 
         expect(user2.active_subscriptions).to contain_exactly(ads_sub, notes_sub)
       end
 
-      it "ignores soft-deleted subscriptions" do
+      it 'ignores soft-deleted subscriptions' do
         ads_sub.soft_delete
         expect(user2.active_subscriptions).to contain_exactly(notes_sub)
 
@@ -769,12 +782,12 @@ describe User do
       end
     end
 
-    describe "#active_subscription_types" do
-      it "returns active subscription types" do
+    describe '#active_subscription_types' do
+      it 'returns active subscription types' do
         expect(user2.active_subscription_types).to contain_exactly(ads,notes)
       end
 
-      it "ignores soft-deleted subscriptions" do
+      it 'ignores soft-deleted subscriptions' do
         user2.unsubscribe_from(ads)
         expect(user2.active_subscription_types).to contain_exactly(notes)
 
@@ -784,15 +797,15 @@ describe User do
     end
   end
 
-  describe ".buyers scope" do
-    include_context "the fresh market"
+  describe '.buyers scope' do
+    include_context 'the fresh market'
 
-    it "returns all users that belong to buying orgs" do
+    it 'returns all users that belong to buying orgs' do
       # NOTE: Barry's in here TWICE because he's a member of two separate Buying orgs.
       expect(User.buyers).to contain_exactly(barry,barry,bill,basil,craig,clarence)
     end
 
-    it "returns all users that belong to buying orgs in the given Market" do
+    it 'returns all users that belong to buying orgs in the given Market' do
       # Barry should still be in twice
       # OMITTED: Steve's a seller (technically he can buy but he's not JUST a buyer)
       # OMITTED: Clarence's link to Fresh Market has been soft deleted
@@ -801,14 +814,14 @@ describe User do
     end
   end
 
-  describe ".sellers scope" do
-    include_context "the fresh market"
-    it "returns users that belong to selling orgs" do
+  describe '.sellers scope' do
+    include_context 'the fresh market'
+    it 'returns users that belong to selling orgs' do
       expect(User.sellers.map(&:name)).to contain_exactly(*[basil, steve, sol, scarbro].map(&:name))
       expect(User.sellers).to contain_exactly(basil, steve, sol, scarbro)
     end
 
-    it "returns users that belong to selling orgs in a market" do
+    it 'returns users that belong to selling orgs in a market' do
       # OMITTED: Sol's link is soft deleted
       # OMITTED: Scarbro's in Other Market
       expect(User.sellers.in_market(fresh_market).map(&:name)).to contain_exactly(*[steve, basil].map(&:name))
@@ -816,37 +829,37 @@ describe User do
     end
   end
 
-  describe "default subscriptions" do
-    include_context "fresh sheet and newsletter subscription types"
-    it "will be Fresh Sheet and Newsletter" do
-      user = User.create!(email:"a@a.a", password:"abcd1234",password_confirmation:"abcd1234")
+  describe 'default subscriptions' do
+    include_context 'fresh sheet and newsletter subscription types'
+    it 'will be Fresh Sheet and Newsletter' do
+      user = User.create!(email:'a@a.a', password:'abcd1234',password_confirmation:'abcd1234')
       expect(user.active_subscription_types).to contain_exactly(fresh_sheet_subscription_type, newsletter_subscription_type)
     end
 
-    it "won't be installed if User is explicitly built with other subscription types" do
-      my_sub_type = create(:subscription_type, name: "Custom type")
-      user = User.create!(subscription_types: [my_sub_type], email:"a@a.a", password:"abcd1234",password_confirmation:"abcd1234")
+    it 'will not be installed if User is explicitly built with other subscription types' do
+      my_sub_type = create(:subscription_type, name: 'Custom type')
+      user = User.create!(subscription_types: [my_sub_type], email:'a@a.a', password:'abcd1234',password_confirmation:'abcd1234')
       expect(user.active_subscription_types).to contain_exactly(my_sub_type)
     end
   end
-  describe "#unsubscribe_token" do
-    include_context "fresh sheet and newsletter subscription types"
+  describe '#unsubscribe_token' do
+    include_context 'fresh sheet and newsletter subscription types'
     let!(:user) { create(:user) }
-    it "gets the token from the Subscription associated with the given SubscriptionType" do
+    it 'gets the token from the Subscription associated with the given SubscriptionType' do
       tolkein = user.unsubscribe_token(subscription_type: fresh_sheet_subscription_type)
       expect(tolkein).to eq(user.subscriptions.find_by(subscription_type: fresh_sheet_subscription_type).token)
     end
   end
 
-  describe "#default_market" do
-    let(:buyer_org1) { create(:organization, :buyer, name: "Buyer Org 1") }
+  describe '#default_market' do
+    let(:buyer_org1) { create(:organization, :buyer, name: 'Buyer Org 1') }
 
-    let(:supplier_org_inactive_newer) { create(:organization, :seller, name: "Inactive Supplier Org 1 (Newer)", active: false) }
-    let(:supplier_org_inactive_older) { create(:organization, :seller, name: "Inactive Supplier Org 2 (Oldest)", active: false, created_at: 1.year.ago) }
+    let(:supplier_org_inactive_newer) { create(:organization, :seller, name: 'Inactive Supplier Org 1 (Newer)', active: false) }
+    let(:supplier_org_inactive_older) { create(:organization, :seller, name: 'Inactive Supplier Org 2 (Oldest)', active: false, created_at: 1.year.ago) }
 
-    let(:supplier_org1) { create(:organization, :seller, name: "Supplier Org 1 (Newer)") }
-    let(:supplier_org2) { create(:organization, :seller, name: "Supplier Org 2 (Older)", created_at: 2.months.ago) }
-    let(:supplier_org3) { create(:organization, :seller, name: "Supplier Org 3 (Oldest)", created_at: 3.years.ago) }
+    let(:supplier_org1) { create(:organization, :seller, name: 'Supplier Org 1 (Newer)') }
+    let(:supplier_org2) { create(:organization, :seller, name: 'Supplier Org 2 (Older)', created_at: 2.months.ago) }
+    let(:supplier_org3) { create(:organization, :seller, name: 'Supplier Org 3 (Oldest)', created_at: 3.years.ago) }
 
     let!(:market_inactive1) { create(:market, name: 'Inactive Market 1', organizations: [buyer_org1, supplier_org1], active: false) }
     let!(:market_inactive2) { create(:market, name: 'Inactive Market 2', organizations: [buyer_org1, supplier_org1, supplier_org2], active: false) }
@@ -854,70 +867,70 @@ describe User do
     let!(:market_active1) { create(:market, name: 'Active Market 1', organizations: [buyer_org1, supplier_org1, supplier_org_inactive_newer]) }
     let!(:market_active2) { create(:market, name: 'Active Market 2', organizations: [buyer_org1, supplier_org3, supplier_org_inactive_older]) }
 
-    context "as an admin" do
+    context 'as an admin' do
       let(:admin_org) { create(:organization, :admin) }
       let(:admin) { create(:user, :admin, organizations: [admin_org]) }
 
-      context "and the 'admin' market exists" do
+      context 'and the admin market exists' do
         let!(:admin_market) { create(:market, subdomain: "admin") }
 
-        it "returns the admin market" do
+        it 'returns the admin market' do
            expect(admin.default_market).to eq(admin_market)
         end
       end
 
-      context "but the 'admin' market doesn't exist" do
-        it "returns nil" do
+      context 'but the admin market does not exist' do
+        it 'returns nil' do
           expect(admin.default_market).to be_nil
         end
       end
     end
 
-    context "as a market manager" do
+    context 'as a market manager' do
       let(:market_manager) { create(:user, :market_manager, managed_markets: managed_markets) }
 
-      context "who manages active and inactive markets" do
+      context 'who manages active and inactive markets' do
         let(:managed_markets) { [market_inactive1, market_active1, market_inactive2] }
 
-        it "returns the first active market" do
+        it 'returns the first active market' do
           expect(market_manager.default_market).to eq(market_active1)
         end
       end
 
-      context "who manages only an inactive market" do
+      context 'who manages only an inactive market' do
         let(:managed_markets) { [market_inactive1] }
 
-        it "returns nil" do
+        it 'returns nil' do
           expect(market_manager.default_market).to be_nil
         end
       end
     end
 
-    context "as a supplier" do
+    context 'as a supplier' do
       let(:supplier) { create(:user, :supplier, organizations: organizations) }
 
-      context "who belongs to an active organization" do
-        context "in both an active and inactive market" do
+      context 'who belongs to an active organization' do
+        context 'in both an active and inactive market' do
           let(:organizations) { [supplier_org1, supplier_org3] }
 
-          it "returns the market associated with the most recently created active organization" do
+          it 'returns the market associated with the most recently created active organization' do
             expect(supplier.default_market).to eq(market_active1)
           end
         end
 
-        context "in an inactive market" do
+        context 'in an inactive market' do
           let(:organizations) { [supplier_org2] }
 
-          it "returns nil" do
+          it 'returns nil' do
             expect(supplier.default_market).to be_nil
           end
         end
       end
 
-      context "who belongs to two inactive organizations in separate active markets" do
+      context 'who belongs to two inactive organizations in separate active markets' do
         let(:organizations) { [supplier_org_inactive_older, supplier_org_inactive_newer] }
 
-        it "returns the market associated with the most recently created inactive organization" do
+        it 'returns the market associated with the most recently created inactive organization' do
           expect(supplier.default_market).to eq(market_active1)
         end
       end


### PR DESCRIPTION
This PR is now ready for review - it might be worth review this on a commit by commit basis.
(Edit: NB - this PR continues based on the bug fix in https://github.com/LocalOrbit/localorbit/pull/3356 - you can skip the first commit if you don't want to go over that work again...)
---

After refactoring Organization types the following specs still passed:

* spec/controllers/admin/fees_controller_spec.rb
* spec/controllers/admin/organizations_controller_spec.rb
* spec/controllers/sessions/organizations_controller_spec.rb
* spec/models/organization_spec.rb
* spec/models/registration_spec.rb
* spec/interactors/send_fresh_sheet_spec.rb

--- 

After reworking the tests (and their wording), a successful fresh sheet spec run now looks like:
```
SendFreshSheet
  sends test emails
  sending to subscribers
    should set success in the interactor context
    fails on bad commit value
    should have valid data in the emails
  finding valid subscribers
    when there are unsubscribed users in the market
      should not find unsubscribed users
    when there unconfirmed users for the market
      should not find unconfirmed users
    when a user's only organization in the market is disabled
      should not find the user
    when a user has active and inactive organizations in the market
      should find the user
    when users exist in other markets
      should not find users only belonging to other markets
    when market users have been deactivated from an organization
      should not find deactivated organization users

Finished in 3.87 seconds (files took 3.61 seconds to load)
10 examples, 0 failures
```

