### PR TITLE
3298 no send update if no change

### DIFF
--- a/app/interactors/send_update_emails.rb
+++ b/app/interactors/send_update_emails.rb
@@ -2,48 +2,8 @@ class SendUpdateEmails
   include Interactor
 
   def perform
-    #return if Rails.env.production?
-
-    #if users_should_be_updated?
-    #  OrderMailer.delay.buyer_order_updated(order)
-    #end
-
-    #if order.is_localeyes_order?
-
-      order.sellers_with_changes.each do |seller|
-        unless seller.users.empty?
-
-          @pack_lists = OrdersBySellerPresenter.new(order.items, seller)
-          @delivery = Delivery.find(order.delivery.id).decorate
-
-          OrderMailer.delay(priority: 10).seller_order_updated(order, seller)
-        end
-      end
-
-      order.sellers_with_cancel.each do |seller|
-        unless seller.users.empty?
-          @pack_lists = OrdersBySellerPresenter.new(order.items, seller)
-          @delivery = Delivery.find(order.delivery.id).decorate
-
-          begin
-            pdf = PackingLists::Generator.generate_pdf(request: request, pack_lists: @pack_lists, delivery: @delivery) if !@pack_lists.sellers.empty?
-          rescue RuntimeError => e
-            pdf = nil
-            Rollbar.error(e, 'Failed to generate packing list PDF for seller order item removed email', order_id: order.id)
-          end
-
-          csv = PackingLists::Generator.generate_csv(pack_lists: @pack_lists) if !@pack_lists.sellers.empty?
-
-          OrderMailer.delay(priority: 10).seller_order_item_removal(order, seller, pdf, csv)
-        end
-      end
-
-
-  #end
-
-    #unless order.market.managers.empty?
-    #  OrderMailer.delay.market_manager_order_updated(order)
-    #end
+    send_update_to_sellers order.sellers_with_changes
+    send_update_to_sellers order.sellers_with_cancel
   end
 
   def users_should_be_updated?
@@ -71,4 +31,17 @@ class SendUpdateEmails
     end
   end
 
+  private
+
+  def send_update_to_sellers(sellers)
+    sellers.each do |seller|
+      if seller.users.present?
+        OrderMailer.
+          delay(priority: 10).
+          seller_order_updated(order, seller)
+      else
+        ap "Warning: trying to send update email to seller with no users."
+      end
+    end
+  end
 end

--- a/app/interactors/send_update_emails.rb
+++ b/app/interactors/send_update_emails.rb
@@ -40,7 +40,7 @@ class SendUpdateEmails
           delay(priority: 10).
           seller_order_updated(order, supplier)
       else
-        ap "Warning: trying to send update email to supplier with no users."
+        Rollbar.warning("Warning: Trying to send update email (for order id ##{order.id}) to supplier (#{supplier.id} - #{supplier.name}) with 0 users")
       end
     end
   end

--- a/app/interactors/send_update_emails.rb
+++ b/app/interactors/send_update_emails.rb
@@ -2,8 +2,8 @@ class SendUpdateEmails
   include Interactor
 
   def perform
-    send_update_to_sellers order.sellers_with_changes
-    send_update_to_sellers order.sellers_with_cancel
+    send_update_to_suppliers order.sellers_with_changes
+    send_update_to_suppliers order.sellers_with_cancel
   end
 
   def users_should_be_updated?
@@ -33,14 +33,14 @@ class SendUpdateEmails
 
   private
 
-  def send_update_to_sellers(sellers)
-    sellers.each do |seller|
-      if seller.users.present?
+  def send_update_to_suppliers(suppliers)
+    suppliers.each do |supplier|
+      if supplier.users.present?
         OrderMailer.
           delay(priority: 10).
-          seller_order_updated(order, seller)
+          seller_order_updated(order, supplier)
       else
-        ap "Warning: trying to send update email to seller with no users."
+        ap "Warning: trying to send update email to supplier with no users."
       end
     end
   end

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -10,7 +10,7 @@ class OrderMailer < BaseMailer
     if !to_list.blank?
       mail(
         to: to_list,
-        subject: "Thank you for your order"
+        subject: 'Thank you for your order'
       )
     end
   end
@@ -54,13 +54,13 @@ class OrderMailer < BaseMailer
     @market = @order.market
     return if @market.is_consignment_market?
 
-    attachments["invoice.pdf"] = {mime_type: "application/pdf", content: @order.invoice_pdf.try(:data)}
+    attachments['invoice.pdf'] = {mime_type: 'application/pdf', content: @order.invoice_pdf.try(:data)}
 
     to_list = recipient_list(@order)
     if !to_list.blank?
       mail(
         to: to_list,
-        subject: "New Invoice"
+        subject: 'New Invoice'
       )
     end
   end
@@ -74,7 +74,7 @@ class OrderMailer < BaseMailer
     mail(
       to: recipient_list(order),
       subject: "#{@market.name}: Order #{order.order_number} Updated",
-      template_name: "order_updated"
+      template_name: 'order_updated'
     )
   end
 
@@ -87,26 +87,28 @@ class OrderMailer < BaseMailer
     mail(
         to: recipient_list(order),
         subject: "#{@market.name}: Order #{order.order_number} Updated - Item Removed",
-        template_name: "order_updated"
+        template_name: 'order_updated'
     )
   end
 
   def seller_order_updated(order, seller)
     return if order.market.is_consignment_market?
 
-    @market = order.market
-    @order = SellerOrder.new(order, seller) # Selling users organizations only see
-    @seller = seller
-
     to_list = seller.
                 users.
                 map { |u| u.enabled_for_organization?(seller) ? u.pretty_email : nil}.
                 compact
 
+    return if to_list.blank?
+
+    @market = order.market
+    @order = SellerOrder.new(order, seller) # Selling users organizations only see
+    @seller = seller
+
     mail(
       to: to_list,
       subject: "#{@market.name}: Order #{order.order_number} Updated",
-      template_name: "order_updated"
+      template_name: 'order_updated'
     )
   end
 
@@ -119,26 +121,21 @@ class OrderMailer < BaseMailer
     mail(
       to: order.market.managers.map(&:pretty_email),
       subject: "#{@market.name}: Order #{order.order_number} Updated",
-      template_name: "order_updated"
+      template_name: 'order_updated'
     )
   end
 
-  def seller_order_item_removal(order, seller, pdf, csv)
+  def seller_order_item_removal(order, seller)
     return if order.market.is_consignment_market?
 
     @market = order.market
     @order = SellerOrder.new(order, seller) # Selling users organizations only see
     @seller = seller
 
-    if pdf
-      attachments["packing_list.pdf"] = {mime_type: "application/pdf", content: pdf.data}
-      attachments["packing_list.csv"] = {mime_type: "application/csv", content: csv}
-    end
-
     mail(
         to: seller.users.map(&:pretty_email),
         subject: "#{@market.name}: Order #{order.order_number} Updated - Item Removed",
-        template_name: "order_updated"
+        template_name: 'order_updated'
     )
   end
 

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -1,45 +1,37 @@
 class OrderMailer < BaseMailer
   def buyer_confirmation(order)
-    @market = order.market
-    return if @market.is_consignment_market?
+    return if order.market.is_consignment_market?
+    to_list = recipient_list(order.organization)
+    return if to_list.blank?
 
+    @market = order.market
     @order = BuyerOrder.new(order)
 
-    to_list = recipient_list(order)
-
-    if !to_list.blank?
-      mail(
-        to: to_list,
-        subject: 'Thank you for your order'
-      )
-    end
+    mail(
+      to: to_list,
+      subject: 'Thank you for your order'
+    )
   end
 
   def seller_confirmation(order, seller)
-    @market = order.market
-    return if @market.is_consignment_market?
+    return if order.market.is_consignment_market?
+    to_list = recipient_list(seller)
+    return if to_list.blank?
 
+    @market = order.market
     @order = SellerOrder.new(order, seller) # Selling users organizations only see
     @seller = seller
 
-    to_list = seller.
-                users.
-                confirmed.
-                map { |u| u.enabled_for_organization?(seller) && !u.pretty_email.nil? ? u.pretty_email : nil}.
-                compact
-
-    if !to_list.blank?
-      mail(
-        to: to_list,
-        subject: "New order on #{@market.name}"
-      )
-    end
+    mail(
+      to: to_list,
+      subject: "New order on #{@market.name}"
+    )
   end
 
   def market_manager_confirmation(order)
-    @market = order.market
-    return if @market.is_consignment_market?
+    return if order.market.is_consignment_market?
 
+    @market = order.market
     @order = BuyerOrder.new(order) # Market Managers should see all items
 
     mail(
@@ -49,43 +41,46 @@ class OrderMailer < BaseMailer
   end
 
   def invoice(order_id)
-
     @order  = BuyerOrder.new(Order.find(order_id))
+    return if @order.blank? || @order.market.is_consignment_market?
+    to_list = recipient_list(@order.organization)
+    return if to_list.blank?
+
     @market = @order.market
-    return if @market.is_consignment_market?
 
     attachments['invoice.pdf'] = {mime_type: 'application/pdf', content: @order.invoice_pdf.try(:data)}
 
-    to_list = recipient_list(@order)
-    if !to_list.blank?
-      mail(
-        to: to_list,
-        subject: 'New Invoice'
-      )
-    end
+    mail(
+      to: to_list,
+      subject: 'New Invoice'
+    )
   end
 
   def buyer_order_updated(order)
-    @market = order.market
-    return if @market.is_consignment_market?
+    return if order.market.is_consignment_market?
+    to_list = recipient_list(order.organization)
+    return if to_list.blank?
 
+    @market = order.market
     @order = BuyerOrder.new(order) # Market Managers should see all items
 
     mail(
-      to: recipient_list(order),
+      to: to_list,
       subject: "#{@market.name}: Order #{order.order_number} Updated",
       template_name: 'order_updated'
     )
   end
 
   def buyer_order_removed(order)
-    @market = order.market
-    return if @market.is_consignment_market?
+    return if order.market.is_consignment_market?
+    to_list = recipient_list(order.organization)
+    return if to_list.blank?
 
+    @market = order.market
     @order = BuyerOrder.new(order) # Market Managers should see all items
 
     mail(
-        to: recipient_list(order),
+        to: to_list,
         subject: "#{@market.name}: Order #{order.order_number} Updated - Item Removed",
         template_name: 'order_updated'
     )
@@ -93,12 +88,7 @@ class OrderMailer < BaseMailer
 
   def seller_order_updated(order, seller)
     return if order.market.is_consignment_market?
-
-    to_list = seller.
-                users.
-                map { |u| u.enabled_for_organization?(seller) ? u.pretty_email : nil}.
-                compact
-
+    to_list = recipient_list(seller)
     return if to_list.blank?
 
     @market = order.market
@@ -127,26 +117,27 @@ class OrderMailer < BaseMailer
 
   def seller_order_item_removal(order, seller)
     return if order.market.is_consignment_market?
+    to_list = recipient_list(seller)
+    return if to_list.blank?
 
     @market = order.market
     @order = SellerOrder.new(order, seller) # Selling users organizations only see
     @seller = seller
 
     mail(
-        to: seller.users.map(&:pretty_email),
-        subject: "#{@market.name}: Order #{order.order_number} Updated - Item Removed",
-        template_name: 'order_updated'
+      to: to_list,
+      subject: "#{@market.name}: Order #{order.order_number} Updated - Item Removed",
+      template_name: 'order_updated'
     )
   end
 
   private
 
-  def recipient_list(order)
-    order.
-      organization.
+  def recipient_list(organization)
+    organization.
       users.
       confirmed.
-      map { |u| u.enabled_for_organization?(order.organization) ? u.pretty_email : nil}.
+      map { |u| u.enabled_for_organization?(organization) ? u.pretty_email : nil}.
       compact
   end
 end

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -82,7 +82,6 @@ class OrderMailer < BaseMailer
   def seller_order_updated(order, seller)
     ensure_buysell_and_list(order, seller) do |to_list|
       @order = SellerOrder.new(order, seller)
-      @seller = seller
       mail(
         to: to_list,
         subject: "#{@market.name}: Order #{order.order_number} Updated",
@@ -94,7 +93,6 @@ class OrderMailer < BaseMailer
   def seller_order_item_removal(order, seller)
     ensure_buysell_and_list(order, seller) do |to_list|
       @order = SellerOrder.new(order, seller)
-      @seller = seller
       mail(
         to: to_list,
         subject: "#{@market.name}: Order #{order.order_number} Updated - Item Removed",

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -5,7 +5,7 @@ class OrderMailer < BaseMailer
     @market = order.market
     @order = BuyerOrder.new(order) # Market Managers should see all items
     mail(
-      to: order.market.managers.map(&:pretty_email),
+      to: @market.managers.map(&:pretty_email),
       subject: "#{@market.name}: Order #{order.order_number} Updated",
       template_name: 'order_updated'
     )
@@ -17,7 +17,7 @@ class OrderMailer < BaseMailer
     @market = order.market
     @order = BuyerOrder.new(order) # Market Managers should see all items
     mail(
-      to: order.market.managers.map(&:pretty_email),
+      to: @market.managers.map(&:pretty_email),
       subject: "New order on #{@market.name}"
     )
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -359,16 +359,6 @@ class Order < ActiveRecord::Base
     Product.arel_table[:id].in(CrossSellingListProduct.joins(:cross_selling_list).where("cross_selling_lists.deleted_at IS NULL AND cross_selling_lists.status = 'Published' AND cross_selling_lists.entity_type = 'Market' AND cross_selling_lists.creator = ? AND cross_selling_lists.entity_id IN (?)", true, user.markets.pluck(:id)).select(:product_id).arel)
   end
 
-  # def self.add_notes_reference(notes_arr) # TODO check aeren
-  #   #org = current_organization
-  #   #binding.pry
-  #   self.delivery_notes = notes_arr.select{|n| n if n.supplier_org == current_organization.id}
-  # end
-
-  # def delivery_notes
-  #   self.delivery_notes
-  # end
-
   def add_cart_items(cart_items, deliver_on)
     cart_items.each do |cart_item|
       add_cart_item(cart_item, deliver_on)

--- a/spec/interactors/send_update_emails_spec.rb
+++ b/spec/interactors/send_update_emails_spec.rb
@@ -1,26 +1,72 @@
 require "spec_helper"
 
 describe SendUpdateEmails do
-  let!(:market) { create(:market) }
+  let!(:market)       { create(:market) }
 
-  let!(:seller1) { create(:organization, :seller, markets: [market]) }
-  let!(:product1) { create(:product, :sellable, organization: seller1) }
-  let!(:seller_user1)    { create(:user, :supplier, organizations: [seller1]) }
+  let!(:seller1)      { create(
+                          :organization,
+                          :seller,
+                          name: 'seller1',
+                          markets: [market]) }
 
-  let!(:seller2) { create(:organization, :seller, markets: [market]) }
-  let!(:product2) { create(:product, :sellable, organization: seller2) }
-  let!(:seller_user2) { create(:user, :supplier, organizations: [seller2]) }
+  let!(:seller1_user) { create(
+                          :user,
+                          :supplier,
+                          organizations: [seller1]) }
 
-  let!(:buyer) { create(:organization, :buyer, markets: [market]) }
-  let!(:buyer_user) { create(:user, :buyer, organizations: [buyer]) }
+  let!(:product1)     { create(
+                          :product,
+                          :sellable,
+                          organization: seller1) }
 
-  let!(:order)    { create(:order, market: market, organization: buyer) }
-  let!(:item1)    { create(:order_item, product: product1, unit_price: 2.00, quantity: 4, order: order) }
-  let!(:item2)    { create(:order_item, product: product2, unit_price: 4.00, quantity: 2, order: order) }
+  let!(:seller2)      { create(
+                          :organization,
+                          :seller,
+                          name: 'seller2',
+                          markets: [market]) }
+
+  let!(:seller2_user) { create(
+                          :user,
+                          :supplier,
+                          organizations: [seller2]) }
+
+  let!(:product2)     { create(
+                          :product,
+                          :sellable,
+                          organization: seller2) }
+
+  let!(:buyer)        { create(
+                          :organization,
+                          :buyer,
+                          markets: [market]) }
+
+  let!(:buyer_user)   { create(
+                          :user,
+                          :buyer,
+                          organizations: [buyer]) }
+
+  let!(:order)        { create(
+                          :order,
+                          market: market,
+                          organization: buyer) }
+
+  let!(:item1)        { create(
+                          :order_item,
+                          product: product1,
+                          unit_price: 2.00,
+                          quantity: 4,
+                          order: order) }
+
+  let!(:item2)        { create(
+                          :order_item,
+                          product: product2,
+                          unit_price: 4.00,
+                          quantity: 2,
+                          order: order) }
 
   let(:update_params) { { updated_at: Time.current } }
 
-  let!(:plan)     { create(:plan, :localeyes) }
+  let!(:plan)         { create(:plan, :localeyes) }
 
   before do
     Order.enable_auditing
@@ -50,29 +96,19 @@ describe SendUpdateEmails do
       }
     end
 
-=begin
-    it "sends an email to users in the organization" do
-      request = @request
-      expect_any_instance_of(OrderMailer).to receive(:buyer_order_updated).with(order)
-
-      SendUpdateEmails.perform(order: order, request: request)
-    end
-=end
-
     it "sends an email to sellers whose items have been updated" do
       request = @request
 
       if order.market.organization.plan == plan
         expect_any_instance_of(OrderMailer).to receive(:seller_order_updated)
         SendUpdateEmails.perform(order: order, request: request)
+
       end
     end
 
     it "does not send an email to sellers whose items have not been updated" do
       request = @request
-
       expect_any_instance_of(OrderMailer).to_not receive(:seller_order_updated).with(order, seller2, nil, nil)
-
       SendUpdateEmails.perform(order: order, request: request)
     end
   end

--- a/spec/interactors/send_update_emails_spec.rb
+++ b/spec/interactors/send_update_emails_spec.rb
@@ -73,22 +73,20 @@ describe SendUpdateEmails do
     OrderItem.enable_auditing
 
     order.reload.update(update_params)
-    # UpdateQuantities.perform(order: order.reload, order_params: update_params)
 
     OrderItem.disable_auditing
     Order.disable_auditing
 
     # Set all audits to be the same request
     Audit.all.update_all(request_uuid: SecureRandom.uuid)
-
   end
 
-  context "a update that should send an email" do
+  context 'a update that should send an email' do
     let!(:update_params) do
       {
         updated_at: Time.current,
         items_attributes: {
-          "0" => {
+          '0' => {
             id: item1.id,
             quantity: 5
           }
@@ -96,54 +94,27 @@ describe SendUpdateEmails do
       }
     end
 
-    it "sends an email to sellers whose items have been updated" do
+    it 'sends an email to sellers whose items have been updated' do
       request = @request
-
       if order.market.organization.plan == plan
         expect_any_instance_of(OrderMailer).to receive(:seller_order_updated)
         SendUpdateEmails.perform(order: order, request: request)
-
       end
     end
 
-    it "does not send an email to sellers whose items have not been updated" do
+    it 'does not send an email to sellers whose items have not been updated' do
       request = @request
       expect_any_instance_of(OrderMailer).to_not receive(:seller_order_updated).with(order, seller2, nil, nil)
       SendUpdateEmails.perform(order: order, request: request)
     end
   end
 
-  context "when an order item has been deleted" do
-    let!(:update_params) do
-      {
-        items_attributes: {
-          "0"=>{
-            id: item1.id.to_s,
-            quantity: "2",
-            "_destroy" => "true"
-          }
-        }
-      }
-    end
-
-=begin
-    it "sends an email to users in the organization" do
-      expect_any_instance_of(OrderMailer).to receive(:buyer_order_updated).with(order)
-      request = @request
-
-      expect {
-        SendUpdateEmails.perform(order: order, request: request)
-      }.to_not raise_error
-    end
-=end
-  end
-
-  context "a update that should not send emails" do
+  context 'a update that should not send emails' do
     let!(:update_params) do
       {
         updated_at: Time.current,
         items_attributes: {
-          "0" => {
+          '0' => {
             id: item1.id,
             quantity_delivered: 4
           }
@@ -151,14 +122,14 @@ describe SendUpdateEmails do
       }
     end
 
-    it "does not send an email to users in the organization" do
+    it 'does not send an email to users in the organization' do
       request = @request
       expect_any_instance_of(OrderMailer).not_to receive(:buyer_order_updated)
 
       SendUpdateEmails.perform(request: request, order: order)
     end
 
-    it "does not send an email to sellers whose items have not been updated" do
+    it 'does not send an email to sellers whose items have not been updated' do
       request = @request
       expect_any_instance_of(OrderMailer).not_to receive(:seller_order_updated)
 

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -1,103 +1,98 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe OrderMailer do
   let!(:market)            { create(:market) }
   let!(:delivery_schedule) { create(:delivery_schedule, market: market) }
   let!(:delivery)          { create(:delivery, delivery_schedule: delivery_schedule) }
-  let!(:seller1)           { create(:organization, :seller, name: "Grandville Farms", can_sell: true, markets: [market]) }
-  let!(:seller2)           { create(:organization, :seller, name: "Zeeland Farms", can_sell: true, markets: [market]) }
-  let!(:buyer)             { create(:organization, :buyer, name: "Hudsonville Restaurant", can_sell: false, markets: [market]) }
-  let!(:users)             { create_list(:user, 2, organizations: [seller1]) }
+  let!(:supplier1)         { create(:organization, :seller, name: 'Grandville Farms', markets: [market]) }
+  let!(:supplier2)         { create(:organization, :seller, name: 'Zeeland Farms', markets: [market]) }
+  let!(:buyer)             { create(:organization, :buyer, name: 'Hudsonville Restaurant', markets: [market]) }
+  let!(:users)             { create_list(:user, 2, organizations: [supplier1]) }
   let!(:buyer_user)        { create(:user, :buyer, organizations: [buyer]) }
 
-  let!(:product1)          { create(:product, :sellable, organization: seller1) }
-  let!(:product2)          { create(:product, :sellable, organization: seller2) }
+  let!(:product1)          { create(:product, :sellable, organization: supplier1) }
+  let!(:product2)          { create(:product, :sellable, organization: supplier2) }
 
-  let!(:order)             { create(:order, market: market, delivery: delivery, delivery_fees: 3, placed_by: buyer_user, organization: buyer, payment_method: "ach", total_cost: 30.0) }
+  let!(:order)             { create(:order, market: market, delivery: delivery, delivery_fees: 3, placed_by: buyer_user, organization: buyer, payment_method: 'ach', total_cost: 30.0) }
   let!(:order_item1)       { create(:order_item, order: order, product: product1, quantity: 11, unit_price: 2.00) }
   let!(:order_item2)       { create(:order_item, order: order, product: product2, quantity: 4, unit_price: 2.50) }
 
   let!(:csv)               { 'CSV' }
 
-  describe "seller_confirmation" do
-    before do
-      Audit.all.update_all(request_uuid: SecureRandom.uuid)
-      @notification = OrderMailer.seller_confirmation(order.reload, seller1)
+  describe '.seller_confirmation' do
+    let(:notification) { OrderMailer.seller_confirmation(order.reload, supplier1) }
+
+    it 'delivers to all users in the organization' do
+      expect(notification).to deliver_to(users.map(&:email))
     end
 
-    it "delivers to all users in the organization" do
-      expect(@notification).to deliver_to(users.map(&:email))
+    it 'shows the seller what order the notification relates to' do
+      expect(notification).to have_body_text("Order Number: #{order.order_number}")
     end
 
-    it "shows the seller what order the notification relates to" do
-      expect(@notification).to have_body_text("Order Number: #{order.order_number}")
+    it 'shows what market the order is from' do
+      expect(notification).to have_subject("New order on #{market.name}")
     end
 
-    it "shows what market the order is from" do
-      expect(@notification).to have_subject("New order on #{market.name}")
-    end
-
-    it "shows what buyer made the order" do
-      expect(@notification).to have_body_text(
+    it 'shows what buyer made the order' do
+      expect(notification).to have_body_text(
         "An order was just placed by <strong>#{buyer.name}</strong>"
       )
     end
 
-    it "shows how the seller should view the order details" do
-      expect(@notification).to have_body_text("following the link below and logging in to your #{seller1.name} account")
+    it 'shows how the seller should view the order details' do
+      expect(notification).to have_body_text("following the link below and logging in to your #{supplier1.name} account")
     end
 
-    it "does not show a previous quantity for an item" do
-      within(".previous-value") do
-        expect(@notification).to_not have_body_text("11 per box")
+    it 'does not show a previous quantity for an item' do
+      within('.previous-value') do
+        expect(notification).to_not have_body_text('11 per box')
       end
     end
 
-    it "does not show delivery fee" do
-      expect(@notification).not_to have_body_text("Delivery Fee")
-    end
-  end
-
-  describe "buyer_confirmation" do
-    before do
-      Audit.all.update_all(request_uuid: SecureRandom.uuid)
-      @notification = OrderMailer.buyer_confirmation(order.reload)
-    end
-    it "shows the delivery fee" do
-      expect(@notification).to have_body_text("Delivery Fee")
+    it 'does not show delivery fee' do
+      expect(notification).not_to have_body_text('Delivery Fee')
     end
   end
 
-  describe "buyer_order_updated" do
-    context "quantities changed" do
+  describe '.buyer_confirmation' do
+    let(:notification) { OrderMailer.buyer_confirmation(order) }
+
+    it 'shows the delivery fee' do
+      expect(notification).to have_body_text('Delivery Fee')
+    end
+  end
+
+  describe '.buyer_order_updated' do
+    context 'quantities changed' do
       before do
         Order.enable_auditing
         OrderItem.enable_auditing
-        order.reload.update(updated_at: Time.current, items_attributes: {"0" => {id: order_item1.id, quantity: 15}})
+        order.reload.update(updated_at: Time.current, items_attributes: {'0' => {id: order_item1.id, quantity: 15}})
         OrderItem.disable_auditing
         Order.disable_auditing
         Audit.all.update_all(request_uuid: SecureRandom.uuid)
         @notification = OrderMailer.buyer_order_updated(order.reload)
       end
 
-      it "has a subject indicating it is an update" do
+      it 'has a subject indicating it is an update' do
         expect(@notification).to have_subject("#{market.name}: Order #{order.order_number} Updated")
       end
 
-      it "shows the old order quantity" do
-        expect(@notification).to have_body_text("11 per box")
+      it 'shows the old order quantity' do
+        expect(@notification).to have_body_text('11 per box')
       end
 
-      it "shows the updated order quantity" do
-        expect(@notification).to have_body_text("15 per box")
+      it 'shows the updated order quantity' do
+        expect(@notification).to have_body_text('15 per box')
       end
     end
 
-    context "canceled items" do
+    context 'canceled items' do
       before do
         Order.enable_auditing
         OrderItem.enable_auditing
-        order.reload.update(updated_at: Time.current, items_attributes: {"0" => {id: order_item1.id, quantity: 0, delivery_status: "canceled"}})
+        order.reload.update(updated_at: Time.current, items_attributes: {'0' => {id: order_item1.id, quantity: 0, delivery_status: 'canceled'}})
         OrderItem.disable_auditing
         Order.disable_auditing
 
@@ -105,28 +100,28 @@ describe OrderMailer do
         @notification = OrderMailer.buyer_order_updated(order.reload)
       end
 
-      it "has a subject indicating it is an update" do
+      it 'has a subject indicating it is an update' do
         expect(@notification).to have_subject("#{market.name}: Order #{order.order_number} Updated")
       end
 
-      it "shows canceled items quantity as 0" do
-        expect(@notification).to have_body_text("0 per box")
+      it 'shows canceled items quantity as 0' do
+        expect(@notification).to have_body_text('0 per box')
       end
 
-      it "does not show the canceled items previous quantity" do
-        expect(@notification).to_not have_body_text("11 per box")
+      it 'does not show the canceled items previous quantity' do
+        expect(@notification).to_not have_body_text('11 per box')
       end
 
-      it "shows the item as being canceled" do
-        expect(@notification).to have_body_text("canceled")
+      it 'shows the item as being canceled' do
+        expect(@notification).to have_body_text('canceled')
       end
     end
 
-    context "refund amount" do
+    context 'refund amount' do
       before do
         Order.enable_auditing
         OrderItem.enable_auditing
-        order.reload.update(updated_at: Time.current, items_attributes: {"0" => {id: order_item1.id, quantity: 5}})
+        order.reload.update(updated_at: Time.current, items_attributes: {'0' => {id: order_item1.id, quantity: 5}})
         OrderItem.disable_auditing
         Order.disable_auditing
 
@@ -134,16 +129,16 @@ describe OrderMailer do
         @notification = OrderMailer.buyer_order_updated(order.reload)
       end
 
-      it "shows the refund amount" do
-        expect(@notification).to have_body_text("refund of $3.00")
+      it 'shows the refund amount' do
+        expect(@notification).to have_body_text('refund of $3.00')
       end
     end
 
-    context "increasing the quantity" do
+    context 'increasing the quantity' do
       before do
         Order.enable_auditing
         OrderItem.enable_auditing
-        order.reload.update(updated_at: Time.current, items_attributes: {"0" => {id: order_item1.id, quantity: 15}})
+        order.reload.update(updated_at: Time.current, items_attributes: {'0' => {id: order_item1.id, quantity: 15}})
         OrderItem.disable_auditing
         Order.disable_auditing
 
@@ -151,107 +146,143 @@ describe OrderMailer do
         @notification = OrderMailer.buyer_order_updated(order.reload)
       end
 
-      it "does not show the refund section" do
-        expect(@notification).to_not have_body_text("refund")
+      it 'does not show the refund section' do
+        expect(@notification).to_not have_body_text('refund')
       end
     end
   end
 
-  describe "seller_order_updated" do
-    context "quantities changed" do
+  describe '.seller_order_updated' do
+    let(:notification) { OrderMailer.seller_order_updated(order, supplier_org) }
+
+    context 'quantities changed' do
+      let(:supplier_org) { supplier1 }
+
       before do
         Order.enable_auditing
         OrderItem.enable_auditing
-        order.reload.update(updated_at: Time.current, items_attributes: {"0" => {id: order_item1.id, quantity: 15}})
+        order.reload.update(updated_at: Time.current, items_attributes: {'0' => {id: order_item1.id, quantity: 15}})
         OrderItem.disable_auditing
         Order.disable_auditing
 
         Audit.all.update_all(request_uuid: SecureRandom.uuid)
-        @notification = OrderMailer.seller_order_updated(order.reload, seller1)
+        @notification = OrderMailer.seller_order_updated(order.reload, supplier1)
       end
 
-      it "has a subject indicating it is an update" do
+      it 'has a subject indicating it is an update' do
         expect(@notification).to have_subject("#{market.name}: Order #{order.order_number} Updated")
       end
 
-      it "shows the old order quantity" do
-        expect(@notification).to have_body_text("11 per box")
+      it 'shows the old order quantity' do
+        expect(@notification).to have_body_text('11 per box')
       end
 
-      it "shows the updated order quantity" do
-        expect(@notification).to have_body_text("15 per box")
+      it 'shows the updated order quantity' do
+        expect(@notification).to have_body_text('15 per box')
       end
 
-      it "does not show other seller items" do
+      it 'does not show other seller items' do
         expect(@notification).to_not have_body_text(product2.name)
       end
     end
 
-    context "canceled items" do
+    context 'canceled items' do
+      let(:supplier_org) { supplier1 }
+
       before do
         Order.enable_auditing
         OrderItem.enable_auditing
-        order.reload.update(updated_at: Time.current, items_attributes: {"0" => {id: order_item1.id, quantity: 0, delivery_status: "canceled"}})
+        order.reload.update(updated_at: Time.current, items_attributes: {'0' => {id: order_item1.id, quantity: 0, delivery_status: 'canceled'}})
         OrderItem.disable_auditing
         Order.disable_auditing
 
         Audit.all.update_all(request_uuid: SecureRandom.uuid)
-        @notification = OrderMailer.seller_order_updated(order.reload, seller1)
+        @notification = OrderMailer.seller_order_updated(order.reload, supplier1)
       end
 
-      it "has a subject indicating it is an update" do
+      it 'has a subject indicating it is an update' do
         expect(@notification).to have_subject("#{market.name}: Order #{order.order_number} Updated")
       end
 
-      it "shows canceled items quantity as 0" do
-        expect(@notification).to have_body_text("0 per box")
+      it 'shows canceled items quantity as 0' do
+        expect(@notification).to have_body_text('0 per box')
       end
 
-      it "shows the item as being canceled" do
-        expect(@notification).to have_body_text("canceled")
+      it 'shows the item as being canceled' do
+        expect(@notification).to have_body_text('canceled')
       end
 
-      it "does not show the canceled items previous quantity" do
-        expect(@notification).to_not have_body_text("10 per box")
+      it 'does not show the canceled items previous quantity' do
+        expect(@notification).to_not have_body_text('10 per box')
       end
 
-      it "does not show other seller items" do
+      it 'does not show other seller items' do
         expect(@notification).to_not have_body_text(product2.name)
       end
     end
 
-    context "refund amount" do
+    xcontext 'refund amount' do
+      let(:supplier_org) { supplier1 }
+
       before do
         Order.enable_auditing
         OrderItem.enable_auditing
-        order.reload.update(updated_at: Time.current, items_attributes: {"0" => {id: order_item1.id, quantity: 5}})
+        order.reload.update(updated_at: Time.current, items_attributes: {'0' => {id: order_item1.id, quantity: 5}})
         OrderItem.disable_auditing
         Order.disable_auditing
-        pdf = PdfResult.new(data: "data", path: "/")
+        pdf = PdfResult.new(data: 'data', path: '/')
 
         Audit.all.update_all(request_uuid: SecureRandom.uuid)
-        @notification = OrderMailer.seller_order_updated(order.reload, seller1, pdf, csv)
+        @notification = OrderMailer.seller_order_updated(order.reload, supplier1)
       end
 
-      #it "shows the refund amount" do
-      #  expect(@notification).to have_body_text("refund of $3.00")
-      #end
+      it 'shows the refund amount' do
+       expect(@notification).to have_body_text('refund of $3.00')
+      end
     end
 
-    context "increasing the quantity" do
+    context 'increasing the quantity' do
       before do
         Order.enable_auditing
         OrderItem.enable_auditing
-        order.reload.update(updated_at: Time.current, items_attributes: {"0" => {id: order_item1.id, quantity: 15}})
+        order.reload.update(updated_at: Time.current, items_attributes: {'0' => {id: order_item1.id, quantity: 15}})
         OrderItem.disable_auditing
         Order.disable_auditing
 
         Audit.all.update_all(request_uuid: SecureRandom.uuid)
-        @notification = OrderMailer.seller_order_updated(order.reload, seller1)
+        @notification = OrderMailer.seller_order_updated(order.reload, supplier1)
       end
 
-      it "does not show the refund section" do
-        expect(@notification).to_not have_body_text("refund")
+      it 'does not show the refund section' do
+        expect(@notification).to_not have_body_text('refund')
+      end
+    end
+
+    context 'when supplier org has no users' do
+      let(:supplier_org) { create(:organization, :seller, markets: [market]) }
+
+      it 'no email is sent' do
+        expect(notification).to be_kind_of(ActionMailer::Base::NullMail)
+      end
+    end
+
+    context 'when supplier org has only unconfirmed users' do
+      let(:supplier_org)      { create(:organization, :seller, markets: [market]) }
+      let!(:unconfirmed_users) { create_list(:user, 2, confirmed_at: nil, organizations: [supplier_org]) }
+
+      it 'no email is sent' do
+        expect(notification).to be_kind_of(ActionMailer::Base::NullMail)
+      end
+    end
+
+    context 'when supplier org has both confirmed and unconfirmed users' do
+      let(:supplier_org)       { create(:organization, :seller, markets: [market]) }
+      let!(:confirmed_user1)   { create(:user, confirmed_at: Time.now, organizations: [supplier_org]) }
+      let!(:confirmed_user2)   { create(:user, confirmed_at: Time.now, organizations: [supplier_org]) }
+      let!(:unconfirmed_user1) { create(:user, confirmed_at: nil, organizations: [supplier_org]) }
+
+      it 'email is sent to only confirmed users' do
+        expect(notification).to be_delivered_to([confirmed_user1.email, confirmed_user2.email])
       end
     end
   end
@@ -260,7 +291,7 @@ describe OrderMailer do
     let(:notification) { OrderMailer.invoice(order.id) }
 
     it 'delivers to all users in the buyer organization' do
-      expect(notification).to deliver_to(buyer_user.email)
+      expect(notification).to be_delivered_to(buyer_user.email)
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -118,6 +118,7 @@ describe Order do
   end
 
   describe ".orders_for_buyer" do
+
     context "admin" do
       let(:market)       { create(:market) }
       let!(:delivery_schedule) { create(:delivery_schedule, market: market) }
@@ -418,10 +419,11 @@ describe Order do
         items_attributes: {
           "0" => {
             id: order_item1.id,
-            quantity: 4
+            quantity: 2
           },
           "1" => {
             id: order_item2.id,
+            quantity: 3,
             quantity_delivered: 4
           },
           "2" => {
@@ -445,13 +447,11 @@ describe Order do
 
     it "returns sellers where the item quantity has changed" do
       sellers_with_change = order.reload.sellers_with_changes
-
-      expect(sellers_with_change).to eql([seller1])
+      expect(sellers_with_change).to eql([seller2])
     end
 
     it "returns sellers where the item has been deleted" do
       sellers_with_remove = order.reload.sellers_with_cancel
-
       expect(sellers_with_remove).to eql([seller3])
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -17,11 +17,6 @@ describe Order do
       expect(subject).to have(1).error_on(:delivery_id)
     end
 
-    #it "requires a order number" do
-    #  expect(subject).to be_invalid
-    #  expect(subject).to have(1).error_on(:order_number)
-    #end
-
     it "requires a placed_at date" do
       expect(subject).to be_invalid
       expect(subject).to have(1).error_on(:placed_at)


### PR DESCRIPTION
Fixes #3347 plus lots of cleanups.

* merged in Rob's work from `seller_order_update_no_recipient_3347` branch
* removes packing list PDF & csv from supplier update emails when supplier's part of the order was cancelled. (As per [Rob in slack ](https://localorbit.slack.com/archives/G8857U3H7/p1534291598000100) ) (though it's TBD if this code works / ever gets executed anyway...) 

---

The following specs have been reviewed and run green
* `spec/interactors/send_update_emails_spec.rb`
* `spec/mailers/order_mailer_spec.rb` 
* `spec/models/order_spec.rb`

That said, I couldn't reproduce the issue (#3298) via tests locally so there is still a possibility that the root cause is still outstanding.
