### PR TITLE
fix 404 on error and allow purchase of future inventory

### DIFF
--- a/app/interactors/create_order.rb
+++ b/app/interactors/create_order.rb
@@ -31,7 +31,6 @@ class CreateOrder
   end
 
   def create_order_from_cart(params, cart, user)
-
     billing = cart.organization.locations.default_billing
     order = Order.new(
       payment_provider: payment_provider,

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -124,9 +124,7 @@ class OrderItem < ActiveRecord::Base
     return unless product.present? && !order.nil? && order.market.is_buysell_market?
 
     qty = product.lots_by_expiration.available_specific(Time.current.end_of_minute, order.market_id, order.organization_id).sum(:quantity)
-    #if qty == 0
     qty += product.lots_by_expiration.available_general(Time.current.end_of_minute).sum(:quantity)
-    #end
     if qty < quantity
       errors[:inventory] = "there are only #{qty} #{product.name.pluralize(qty)} available."
     end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -123,8 +123,8 @@ class OrderItem < ActiveRecord::Base
   def product_availability
     return unless product.present? && !order.nil? && order.market.is_buysell_market?
 
-    qty = product.lots_by_expiration.available_specific(Time.current.end_of_minute, order.market_id, order.organization_id).sum(:quantity)
-    qty += product.lots_by_expiration.available_general(Time.current.end_of_minute).sum(:quantity)
+    qty = product.lots.available_specific(deliver_on_date, order.market_id, order.organization_id).sum(:quantity)
+    qty += product.lots.available_general(deliver_on_date).sum(:quantity)
     if qty < quantity
       errors[:inventory] = "there are only #{qty} #{product.name.pluralize(qty)} available."
     end
@@ -142,8 +142,8 @@ class OrderItem < ActiveRecord::Base
     if !ct.nil? && !ct.empty?
       qty = ct.sum(:quantity)
     elsif !product.lots.empty? && product.lots.sum(:quantity) > 0
-      qty = product.lots_by_expiration.available_specific(Time.current.end_of_minute, market_id, organization_id).sum(:quantity)
-      qty += product.lots_by_expiration.available_general(Time.current.end_of_minute).sum(:quantity)
+      qty = product.lots.available_specific(Time.current.end_of_minute, market_id, organization_id).sum(:quantity)
+      qty += product.lots.available_general(Time.current.end_of_minute).sum(:quantity)
     end
     if qty > 0 && (qty + (quantity_was || 0)) < quantity
       errors.add(:inventory, "there are only #{Integer(qty)} #{product.name.pluralize(qty)} available.")

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -454,14 +454,10 @@ class Product < ActiveRecord::Base
     else
       if lots.loaded?
         qty = lots.to_a.sum {|l| l.available_specific?(deliver_on_date, market_id, organization_id) ? l.quantity : 0 }
-        #if qty == 0
-          qty += lots.to_a.sum {|l| l.available_general?(deliver_on_date) ? l.quantity : 0 }
-        #end
+        qty += lots.to_a.sum {|l| l.available_general?(deliver_on_date) ? l.quantity : 0 }
       else
         qty = lots.available_specific(deliver_on_date, market_id, organization_id).sum(:quantity)
-        #if qty == 0
-          qty += lots.available_general(deliver_on_date).sum(:quantity)
-        #end
+        qty += lots.available_general(deliver_on_date).sum(:quantity)
       end
     end
     qty

--- a/spec/interactors/create_order_spec.rb
+++ b/spec/interactors/create_order_spec.rb
@@ -21,7 +21,7 @@ describe CreateOrder do
     # (It's normally de-activated for tests, see spec/support/audited.rb)
     # I think the ROOT cause of the exception being raised in the first place is a bug in
     # the Audited rubygem: https://github.com/collectiveidea/audited
-    # 
+    #
     # Enabling auditing helps expose the bug that busted us in production. crosby - 2015-07-20
     Order.enable_auditing
   end
@@ -36,7 +36,7 @@ describe CreateOrder do
     it "sets the payment note" do
       expect(subject.payment_note).to eql("1234")
     end
-    
+
     it "sets the payment provider" do
       expect(subject.payment_provider).to eq payment_provider
     end


### PR DESCRIPTION
Fixes:
- should no longer get 404 when saving an order fails
- can now complete a purchase against inventory available in the future even though none available presently, based on delivery date (eg. allocated egg production)

To test:
- Create a product with a lot with good_from and expiry in the future. Make an order with delivery date in between those dates, purchase should complete successfully.