### PR TITLE
Small tweak to show proper unit price when there is cart validation e…

### DIFF
--- a/app/views/orders/_sales_order.html.erb
+++ b/app/views/orders/_sales_order.html.erb
@@ -13,7 +13,7 @@
               <%= content_tag_for(:tr, item, id: item.product.id, class: "product order-item-row", data: {id: item.product.id}) do %>
                 <td class="name"><%= item.product.name %></td>
                 <td class="quantity math"><%= item.decorate.quantity_with_unit %></td>
-                <td class="price math"><%= number_to_currency item.unit_price %></td>
+                <td class="price math"><%= number_to_currency item.unit_price.sale_price %></td>
                 <td class="item-total math"><%= number_to_currency item.gross_total %></td>
               <% end %>
             <% end %>


### PR DESCRIPTION
Instead of showing '$#<Price:0x00007f9e2c023f88>' as the unit price when there is a validation error show the unit price properly.

NOTE: This merges down onto  the `3458_404_on_error_and_purchase_future_inventory` branch.