### PR TITLE
Fixes prod db cleaning

### DIFF
--- a/lib/tasks/production-copy.rake
+++ b/lib/tasks/production-copy.rake
@@ -284,10 +284,10 @@ module CloneProductionHelper
     refs_to_clear += balanced_payments_refs_to_clear
     refs_to_clear += stripe_refs_to_clear
 
-    refs_to_clear.each do |model, fields|
-      fields.each do |field|
-        puts "Setting all #{model.name}##{field} to nil"
-        model.update_all("#{field} = NULL")
+    refs_to_clear.each do |hash|
+      hash[:fields].each do |field|
+        puts "Setting all #{hash[:model].name}##{field} to nil"
+        hash[:model].update_all("#{field} = NULL")
       end
     end
   end


### PR DESCRIPTION
When running `production_copy:cleanse` I ran into an error.
Original version (changed in https://github.com/LocalOrbit/localorbit/commit/fb033cf79723c84b24fcacde19771b7499f527ff ) didn't work, but the 'fix' just made it valid Ruby without actually fixing the issue. This actually fixes the problem. (Note: I'm not sure how the original fix got through.. sorry)
