### PR TITLE
Learn how payment_received mail happens w/ webhook

### DIFF
--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -8,6 +8,7 @@ class PaymentMailer < BaseMailer
   end
 
   def payment_received(recipients, payment)
+    dead_code!
     @payment = payment
     @market  = @payment.market
 

--- a/lib/dead_code.rb
+++ b/lib/dead_code.rb
@@ -4,7 +4,7 @@ module DeadCode
   def dead_code!
     error = NotDeadCodeError.new("NOT dead code: #{caller.first.inspect}")
 
-    if Rails.env[/development|test/]
+    if Rails.env.development?
       raise error
     else
       Rollbar.notify(error)

--- a/lib/payment_provider/handlers/async_handler.rb
+++ b/lib/payment_provider/handlers/async_handler.rb
@@ -15,6 +15,7 @@ module PaymentProvider
         ::Rails::logger.info("WEBHOOK: #{event.type} CONNECT: #{event.try(:account)} LIVEMODE: #{event.livemode}")
         handler = HANDLER_IMPLS[event.type]
         return unless handler
+        Rollbar.info('webhook', event)
 
         params = handler.extract_job_params(event)
         Rails.logger.info "Enqueueing '#{event.type}' event. Stripe Event id: '#{event.id}'"

--- a/lib/payment_provider/handlers/transfer_paid.rb
+++ b/lib/payment_provider/handlers/transfer_paid.rb
@@ -11,6 +11,7 @@ module PaymentProvider
       end
 
       def self.handle(transfer_id:, stripe_account_id:, amount_in_cents:)
+        dead_code!
         if stripe_account_id and market = Market.where('stripe_account_id=? OR legacy_stripe_account_id=?',stripe_account_id,stripe_account_id).first
           order_ids = PaymentProvider::Stripe.order_ids_for_market_payout_transfer(
             transfer_id: transfer_id,


### PR DESCRIPTION
Learn how payment_received mail happens w/ webhook

* change behavior of dead_code helper so that NotDeadCodeError exceptions in test env are ignored unless USE_ROLLBAR is truthy

We'll revert the dead_code! and Rollbar.info once we get some insight.

NOTE: This is a resubmit of the previously approved PR but rebased on `master` with the conflict resolved.