### PR TITLE
Fix "IOError: not opened for reading" errors on staging

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -100,7 +100,7 @@ class OrdersController < ApplicationController
         session.delete(:current_delivery_day)
         @grouped_items = @order.items.for_checkout
       else
-        Rollbar.info('Order could not be completed', context: @placed_order.context)
+        Rollbar.info('Order could not be completed', context_error: @placed_order.context[:error])
 
         if @placed_order.context.key?(:cart_is_empty)
           @grouped_items = current_cart.items.for_checkout


### PR DESCRIPTION
Fix "IOError: not opened for reading" errors on staging when stripe_customer is missing

Error was caused by passing entire context to Rollbar, instead we now just pull out the relevant error message, visible as first piece of meta data in Rollbar, e.g.:
https://rollbar.com/LocalOrbit/Local-Orbit/items/395/occurrences/56179617492/
