### PR TITLE
Don't show long order number list in success message after invoice send/mark

### DIFF
--- a/app/controllers/admin/financials/invoices_controller.rb
+++ b/app/controllers/admin/financials/invoices_controller.rb
@@ -32,8 +32,7 @@ module Admin::Financials
           CreateInvoice.perform(order: order,
                                 request: RequestUrlPresenter.new(request))
         end
-        message = mk_order_number_message what: "Invoice sent", orders: @orders
-        redirect_to admin_financials_invoices_path, notice: message
+        redirect_to admin_financials_invoices_path, notice: "Successfully sent #{@orders.size} #{"invoice".pluralize(@orders.size)}. Sent invoices can be downloaded from the Enter Receipts page."
 
       when "preview-selected-invoices"
         context = InitializeBatchInvoice.perform(user: current_user, orders: @orders)
@@ -58,9 +57,7 @@ module Admin::Financials
             end
           end
 
-          message = mk_order_number_message what: "Invoice marked", orders: @orders
-
-          redirect_to admin_financials_invoices_path, notice: message
+          redirect_to admin_financials_invoices_path, notice: "Successfully marked #{@orders.size} #{"order".pluralize(@orders.size)} invoiced. Invoices can be downloaded from the Enter Receipts page."
         end
 
       when nil, ""
@@ -114,10 +111,6 @@ module Admin::Financials
 
       redirect_path = params[:redirect_to] || admin_financials_invoices_path
       redirect_to redirect_path, notice: resend_message(@orders)
-    end
-
-    def mk_order_number_message(what:,orders:)
-      "#{what} for order #{"number".pluralize(orders.size)} #{orders.map(&:order_number).sort.join(", ")}. Invoices can be downloaded on the Enter Receipts page"
     end
   end
 end

--- a/spec/controllers/admin/financials/invoices_controller_spec.rb
+++ b/spec/controllers/admin/financials/invoices_controller_spec.rb
@@ -25,19 +25,52 @@ describe Admin::Financials::InvoicesController do
   end
 
   describe "#create" do
-    it "tracks the fact we batch previewed some invoices" do
-      post :create, invoice_list_batch_action: "preview-selected-invoices", order_id: [order1.id,order2.id]
+    context 'previews two invoices' do
+      before do
+        post :create, invoice_list_batch_action: "preview-selected-invoices", order_id: [order1.id,order2.id]
+      end
 
-      e = EventTracker.previously_captured_events.first
-      expect(e).to be
-      expect(e).to eq({
-        user: mary,
-        event: EventTracker::PreviewedBatchInvoices.name,
-        metadata: {
-          num_invoices: 2
-        }
-      })
+      it "tracks the fact we batch previewed some invoices" do
+        e = EventTracker.previously_captured_events.first
+        expect(e).to be
+        expect(e).to eq({
+          user: mary,
+          event: EventTracker::PreviewedBatchInvoices.name,
+          metadata: {
+            num_invoices: 2
+          }
+        })
+      end
 
+    end
+
+    context 'sends two invoices' do
+      before do
+        post :create, invoice_list_batch_action: "send-selected-invoices", order_id: [order1.id,order2.id]
+      end
+
+      it 'redirects back to list' do
+        # expect(response).to be_success
+        expect(request).to redirect_to("/admin/financials/invoices")
+      end
+
+      it 'shows right message' do
+        expect(flash[:notice]).to eq('Successfully sent 2 invoices. Sent invoices can be downloaded from the Enter Receipts page.')
+      end
+    end
+
+    context 'marks two invoices as invoiced' do
+      before do
+        post :create, invoice_list_batch_action: "mark-selected-invoiced", order_id: [order1.id,order2.id]
+      end
+
+      it 'redirects back to list' do
+        expect(request).to redirect_to("/admin/financials/invoices")
+      end
+
+      it 'shows right message' do
+        expect(flash[:notice]).to eq('Successfully marked 2 orders invoiced. Invoices can be downloaded from the Enter Receipts page.')
+      end
     end
   end
 end


### PR DESCRIPTION
Aims to be a quick, incomplete fix for #3493. There is a larger issue with sticky filters cookie overload, but this will help in certain instances.